### PR TITLE
멘티, 멘토 권한 수정 기능 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/manager/AuthenticatedUserManager.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/manager/AuthenticatedUserManager.kt
@@ -1,0 +1,51 @@
+package team.themoment.gsmNetworking.common.manager
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.exception.ExpectedException
+import team.themoment.gsmNetworking.domain.auth.domain.Authentication
+import team.themoment.gsmNetworking.domain.auth.domain.Authority
+import team.themoment.gsmNetworking.domain.auth.repository.AuthenticationRepository
+
+@Component
+class AuthenticatedUserManager(
+    private val authenticationRepository: AuthenticationRepository
+) {
+
+    /**
+     * SecurityContextHolder에 담긴 authentication의 name을 가져옵니다.
+     *
+     * @return authentication 객체의 name을 Long으로 변환한 값
+     */
+    fun getName(): Long {
+        val securityContextHolder = SecurityContextHolder.getContext()
+        val authentication = securityContextHolder.authentication
+        return authentication.name.toLong()
+    }
+
+    /**
+     * authentication 엔티티의 권한을 update 합니다.
+     *
+     * @param newAuthority 수정할 사용자의 새로운 권한
+     * @throws ExpectedException 이 터지는 조건은 아래와 같다.
+     *      1. authenticationId를 가진 사용자가 없는 경우
+     */
+    @Transactional(rollbackFor = [Exception::class])
+    fun updateAuthority(newAuthority: Authority) {
+        val authenticationId = this.getName()
+        val authentication = authenticationRepository.findByIdOrNull(authenticationId)
+            ?: throw ExpectedException("인증 절차를 수행하지 않아 id가 없는 사용자 입니다.", HttpStatus.NOT_FOUND)
+        authenticationRepository.save(
+            Authentication(
+                authenticationId = authenticationId,
+                email = authentication.email,
+                providerId = authentication.providerId,
+                authority = newAuthority
+            )
+        )
+    }
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/auth/domain/Authentication.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/auth/domain/Authentication.kt
@@ -10,10 +10,10 @@ class Authentication(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val authenticationId: Long = 0,
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     val email: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     val providerId: String,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.domain.mentee.controller
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,8 +14,8 @@ class MenteeController(
 ) {
 
     @PostMapping
-    fun updateMentee(): ResponseEntity<Map<String, String>> =
+    fun updateMentee(): ResponseEntity<Void> =
         updateMenteeService.execute()
-            .let { ResponseEntity.ok(mapOf("message" to "권한을 수정하였습니다. 토큰을 재발급 해주세요.")) }
+            .let { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
@@ -14,7 +14,7 @@ class MenteeController(
 ) {
 
     @PostMapping
-    fun updateMentee(): ResponseEntity<Void> =
+    fun updateMentee(): ResponseEntity<Unit> =
         updateMenteeService.execute()
             .let { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
@@ -1,6 +1,5 @@
 package team.themoment.gsmNetworking.domain.mentee.controller
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,8 +13,8 @@ class MenteeController(
 ) {
 
     @PostMapping
-    fun updateMentee(): ResponseEntity<Void> =
+    fun updateMentee(): ResponseEntity<Map<String, String>> =
         updateMenteeService.execute()
-            .run { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
+            .let { ResponseEntity.ok(mapOf("message" to "권한을 수정하였습니다. 토큰을 재발급 해주세요.")) }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/controller/MenteeController.kt
@@ -1,0 +1,21 @@
+package team.themoment.gsmNetworking.domain.mentee.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.domain.mentee.service.UpdateMenteeService
+
+@RestController
+@RequestMapping("api/v1/mentee")
+class MenteeController(
+    private val updateMenteeService: UpdateMenteeService
+) {
+
+    @PostMapping
+    fun updateMentee(): ResponseEntity<Void> =
+        updateMenteeService.execute()
+            .run { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/service/UpdateMenteeService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/service/UpdateMenteeService.kt
@@ -1,0 +1,25 @@
+package team.themoment.gsmNetworking.domain.mentee.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
+import team.themoment.gsmNetworking.domain.auth.domain.Authority
+
+/**
+ * 멘티의 정보를 수정하는 로직이 담긴 클래스 입니다.
+ */
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class UpdateMenteeService(
+    private val authenticatedUserManager: AuthenticatedUserManager
+) {
+
+    /**
+     * 멘티의 권한을 수정한다.
+     * 현재 단계에서는 멘티의 정보를 저장하고 있지 않기 때문에, 추후 인증 절차만 건너뛰도록 권한만 수정한다.
+     */
+    fun execute() {
+        authenticatedUserManager.updateAuthority(Authority.TEMP_USER)
+    }
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -16,7 +16,7 @@ class MentorController(
 ) {
 
     @PostMapping
-    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> =
+    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Unit> =
         mentorRegistrationService.execute(dto)
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -1,13 +1,12 @@
 package team.themoment.gsmNetworking.domain.mentor.controller
 
-import team.themoment.gsmNetworking.domain.mentor.dto.MentorRegistrationDto
-import team.themoment.gsmNetworking.domain.mentor.service.MentorRegistrationService
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorRegistrationDto
+import team.themoment.gsmNetworking.domain.mentor.service.MentorRegistrationService
 
 @RestController
 @RequestMapping("api/v1/mentor")
@@ -16,8 +15,8 @@ class MentorController(
 ) {
 
     @PostMapping
-    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> =
+    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Map<String, String>> =
         mentorRegistrationService.execute(dto)
-            .run { ResponseEntity.status(HttpStatus.CREATED).build() }
+            .let { ResponseEntity.ok(mapOf("message" to "권한을 수정하였습니다. 토큰을 재발급 해주세요.")) }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -16,7 +16,7 @@ class MentorController(
 ) {
 
     @PostMapping
-    fun saveMentorInfo(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> =
+    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> =
         mentorRegistrationService.execute(dto)
             .run { ResponseEntity.status(HttpStatus.CREATED).build() }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.domain.mentor.controller
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -15,8 +16,8 @@ class MentorController(
 ) {
 
     @PostMapping
-    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Map<String, String>> =
+    fun mentorRegistration(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> =
         mentorRegistrationService.execute(dto)
-            .let { ResponseEntity.ok(mapOf("message" to "권한을 수정하였습니다. 토큰을 재발급 해주세요.")) }
+            .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -12,6 +12,9 @@ class User(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val userId: Long = 0,
 
+    @Column(nullable = false, unique = true)
+    val authenticationId: Long,
+
     @Column(nullable = false)
     val name: String,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/repository/UserRepository.kt
@@ -9,5 +9,6 @@ import org.springframework.data.repository.CrudRepository
 interface UserRepository: CrudRepository<User, Long> {
 
     fun existsByPhoneNumber(phoneNumber: String): Boolean
+    fun existsByEmail(email: String): Boolean
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/UserRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/UserRegistrationService.kt
@@ -26,6 +26,7 @@ class UserRegistrationService(
     fun execute(dto: UserRegistrationDto): User {
         val authenticationId = authenticatedUserManager.getName()
         validateExistUserByPhoneNumber(dto.phoneNumber)
+        validateExistUserByEmail(dto.email)
         val user = User(
             authenticationId = authenticationId,
             name = dto.name,
@@ -42,6 +43,11 @@ class UserRegistrationService(
     private fun validateExistUserByPhoneNumber(phoneNumber: String) {
         if (userRepository.existsByPhoneNumber(phoneNumber))
             throw ExpectedException("이미 존재하는 핸드폰 번호를 가진 유저 입니다.", HttpStatus.BAD_REQUEST)
+    }
+
+    private fun validateExistUserByEmail(email: String) {
+        if (userRepository.existsByEmail(email))
+            throw ExpectedException("이미 존재하는 email을 가진 유저 입니다.", HttpStatus.BAD_REQUEST)
     }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/UserRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/UserRegistrationService.kt
@@ -1,17 +1,20 @@
 package team.themoment.gsmNetworking.domain.user.service
 
-import team.themoment.gsmNetworking.domain.user.domain.User
-import team.themoment.gsmNetworking.domain.user.dto.UserRegistrationDto
-import team.themoment.gsmNetworking.domain.user.repository.UserRepository
-import team.themoment.gsmNetworking.common.exception.ExpectedException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.exception.ExpectedException
+import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
+import team.themoment.gsmNetworking.domain.auth.domain.Authority
+import team.themoment.gsmNetworking.domain.user.domain.User
+import team.themoment.gsmNetworking.domain.user.dto.UserRegistrationDto
+import team.themoment.gsmNetworking.domain.user.repository.UserRepository
 
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class UserRegistrationService(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val authenticatedUserManager: AuthenticatedUserManager
 ) {
 
     /**
@@ -21,8 +24,10 @@ class UserRegistrationService(
      * @return 저장된 user 엔티티
      */
     fun execute(dto: UserRegistrationDto): User {
+        val authenticationId = authenticatedUserManager.getName()
         validateExistUserByPhoneNumber(dto.phoneNumber)
         val user = User(
+            authenticationId = authenticationId,
             name = dto.name,
             generation = dto.generation,
             email = dto.email,
@@ -30,6 +35,7 @@ class UserRegistrationService(
             snsUrl = dto.snsUrl,
             profileUrl = dto.profileUrl
         )
+        authenticatedUserManager.updateAuthority(Authority.USER)
         return userRepository.save(user)
     }
 


### PR DESCRIPTION
## 개요
- 멘티, 멘토의 권한을 수정하는 기능을 추가하였습니다. 

## 본문

### 추가
- `authentication` 엔티티의 중복되면 안되는 컬럼에 `unique` 옵션을 추가하였습니다. 
- `user` 엔티티에 `authenticationId` 필드를 추가하였습니다. 
- 멘티의 경우 따로 데이터를 저장하는 구조가 아니라서, 권한만 `UNAUTHENTICATED`에서 `TEMP_USER`로 수정하도록 구현하였습니다.

### 수정
- `mentorController`의 멘토 생성 메서드 이름을 `saveMentorInfo`에서 `mentorRegistration`으로 변경하였습니다.