### PR TITLE
멘토 리스트 가져오는 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
 	kotlin("plugin.jpa") version "1.6.21"
+	kotlin("kapt") version "1.4.10"
 }
 
 allOpen {
@@ -44,6 +45,10 @@ dependencies {
 	/** jpa **/
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-jdbc")
+
+	/** queryDsl **/
+	implementation("com.querydsl:querydsl-jpa:5.0.0")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 
 	/* DB */
 	implementation("mysql:mysql-connector-java:8.0.32")

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -2,23 +2,33 @@ package team.themoment.gsmNetworking.domain.mentor.controller
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorRegistrationDto
 import team.themoment.gsmNetworking.domain.mentor.service.MentorRegistrationService
+import team.themoment.gsmNetworking.domain.mentor.service.QueryMentorListService
 
 @RestController
 @RequestMapping("api/v1/mentor")
 class MentorController(
-    private val mentorRegistrationService: MentorRegistrationService
+    private val mentorRegistrationService: MentorRegistrationService,
+    private val queryMentorListService: QueryMentorListService
 ) {
 
     @PostMapping
     fun saveMentorInfo(@RequestBody dto: MentorRegistrationDto): ResponseEntity<Void> {
         mentorRegistrationService.execute(dto)
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping
+    fun queryMentorList(): ResponseEntity<List<MentorInfoDto>> {
+        val mentorList = queryMentorListService.execute()
+        return ResponseEntity.ok(mentorList)
     }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -1,0 +1,18 @@
+package team.themoment.gsmNetworking.domain.mentor.dto
+
+data class MentorInfoDto(
+    private val id: Long,
+    private val name: String,
+    private val email: String,
+    private val generation: Int,
+    private val position: String,
+    private val company: CompanyInfo,
+    private val sns: String
+) {
+
+    data class CompanyInfo(
+        private val name: String,
+        private val url: String
+    )
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -1,5 +1,7 @@
 package team.themoment.gsmNetworking.domain.mentor.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class MentorInfoDto(
     val id: Long,
     val name: String,
@@ -7,12 +9,14 @@ data class MentorInfoDto(
     val generation: Int,
     val position: String,
     val company: CompanyInfo,
+    @field:JsonProperty("SNS")
     val sns: String?,
     val profileUrl: String?
 ) {
 
     data class CompanyInfo(
         val name: String,
+        @field:JsonProperty("URL")
         val url: String
     )
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -1,18 +1,19 @@
 package team.themoment.gsmNetworking.domain.mentor.dto
 
 data class MentorInfoDto(
-    private val id: Long,
-    private val name: String,
-    private val email: String,
-    private val generation: Int,
-    private val position: String,
-    private val company: CompanyInfo,
-    private val sns: String
+    val id: Long,
+    val name: String,
+    val email: String,
+    val generation: Int,
+    val position: String,
+    val company: CompanyInfo,
+    val sns: String?,
+    val profileUrl: String?
 ) {
 
     data class CompanyInfo(
-        private val name: String,
-        private val url: String
+        val name: String,
+        val url: String
     )
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CustomMentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CustomMentorRepository.kt
@@ -1,0 +1,43 @@
+package team.themoment.gsmNetworking.domain.mentor.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import team.themoment.gsmNetworking.domain.mentor.domain.QMentor.mentor
+import team.themoment.gsmNetworking.domain.mentor.domain.QCareer.career
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+
+/**
+ * mentor entity를 queryDsl로 사용하기 위한 custom repository 입니다.
+ */
+@Repository
+class CustomMentorRepository(
+    private val queryFactory: JPAQueryFactory
+) {
+
+    /**
+     * 멘토와 커리어를 조인하여 dto로 감싸 리턴 해주는 메서드 입니다.
+     *
+     * @return 멘토의 정보를 감싼 dto
+     */
+    fun findAllMentorInfoDto(): List<MentorInfoDto> =
+        queryFactory.select(
+            Projections.constructor(
+                MentorInfoDto::class.java,
+                mentor.mentorId,
+                mentor.user.name,
+                mentor.user.email,
+                mentor.user.generation,
+                Projections.constructor(
+                    MentorInfoDto.CompanyInfo::class.java,
+                    career.companyName,
+                    career.companyUrl
+                ),
+                mentor.user.snsUrl
+            )
+        )
+            .from(mentor)
+            .leftJoin(mentor, career.mentor)
+            .fetch()
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CustomMentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CustomMentorRepository.kt
@@ -3,9 +3,10 @@ package team.themoment.gsmNetworking.domain.mentor.repository
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
-import team.themoment.gsmNetworking.domain.mentor.domain.QMentor.mentor
 import team.themoment.gsmNetworking.domain.mentor.domain.QCareer.career
+import team.themoment.gsmNetworking.domain.mentor.domain.QMentor.mentor
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+import team.themoment.gsmNetworking.domain.user.domain.QUser.user
 
 /**
  * mentor entity를 queryDsl로 사용하기 위한 custom repository 입니다.
@@ -28,16 +29,19 @@ class CustomMentorRepository(
                 mentor.user.name,
                 mentor.user.email,
                 mentor.user.generation,
+                career.position,
                 Projections.constructor(
                     MentorInfoDto.CompanyInfo::class.java,
                     career.companyName,
                     career.companyUrl
                 ),
-                mentor.user.snsUrl
+                mentor.user.snsUrl,
+                mentor.user.profileUrl
             )
         )
-            .from(mentor)
-            .leftJoin(mentor, career.mentor)
+            .from(mentor, career)
+            .join(mentor.user, user)
+            .where(mentor.mentorId.eq(career.mentor.mentorId))
             .fetch()
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryMentorListService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryMentorListService.kt
@@ -1,0 +1,26 @@
+package team.themoment.gsmNetworking.domain.mentor.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+import team.themoment.gsmNetworking.domain.mentor.repository.CustomMentorRepository
+
+/**
+ * 멘토의 정보 리스트로 볼 수 있는 로직이 담긴 클래스 입니다.
+ */
+@Service
+@Transactional(readOnly = true)
+class QueryMentorListService(
+    private val customMentorRepository: CustomMentorRepository
+) {
+
+    /**
+     * 멘토 리스트를 가져와서 리턴해주는 메서드 입니다.
+     *
+     * @return 멘토 정보가 담긴 dto 리스트
+     */
+    fun execute(): List<MentorInfoDto> {
+        return customMentorRepository.findAllMentorInfoDto()
+    }
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/config/QueryDslConfig.kt
@@ -1,0 +1,18 @@
+package team.themoment.gsmNetworking.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+
+}


### PR DESCRIPTION
## 개요
- 멘토 리스트를 가져오는 기능을 추가하였습니다.
## 본문
- user, career, mentor 총 3개의 entity 값이 필요한 쿼리라 queryDsl을 추가하여 한 쿼리로 값을 리턴하도록 구현하였습니다.
