### PR TITLE
커스텀 Repository 인터페이스 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepository.kt
@@ -1,0 +1,9 @@
+package team.themoment.gsmNetworking.domain.mentor.repository
+
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+
+interface MentorCustomRepository {
+
+    fun findAllMentorInfoDto(): List<MentorInfoDto>
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
@@ -2,7 +2,6 @@ package team.themoment.gsmNetworking.domain.mentor.repository
 
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.stereotype.Repository
 import team.themoment.gsmNetworking.domain.mentor.domain.QCareer.career
 import team.themoment.gsmNetworking.domain.mentor.domain.QMentor.mentor
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
@@ -11,17 +10,16 @@ import team.themoment.gsmNetworking.domain.user.domain.QUser.user
 /**
  * mentor entity를 queryDsl로 사용하기 위한 custom repository 입니다.
  */
-@Repository
-class CustomMentorRepository(
+class MentorCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
-) {
+): MentorCustomRepository {
 
     /**
      * 멘토와 커리어를 조인하여 dto로 감싸 리턴 해주는 메서드 입니다.
      *
      * @return 멘토의 정보를 감싼 dto
      */
-    fun findAllMentorInfoDto(): List<MentorInfoDto> =
+    override fun findAllMentorInfoDto(): List<MentorInfoDto> =
         queryFactory.select(
             Projections.constructor(
                 MentorInfoDto::class.java,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorRepository.kt
@@ -6,4 +6,4 @@ import org.springframework.data.repository.CrudRepository
 /**
  * Mentor Entity를 위한 Repository 인터페이스 입니다.
  */
-interface MentorRepository: CrudRepository<Mentor, Long>
+interface MentorRepository: CrudRepository<Mentor, Long>, MentorCustomRepository

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryMentorListService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryMentorListService.kt
@@ -3,7 +3,7 @@ package team.themoment.gsmNetworking.domain.mentor.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
-import team.themoment.gsmNetworking.domain.mentor.repository.CustomMentorRepository
+import team.themoment.gsmNetworking.domain.mentor.repository.MentorCustomRepository
 
 /**
  * 멘토의 정보 리스트로 볼 수 있는 로직이 담긴 클래스 입니다.
@@ -11,7 +11,7 @@ import team.themoment.gsmNetworking.domain.mentor.repository.CustomMentorReposit
 @Service
 @Transactional(readOnly = true)
 class QueryMentorListService(
-    private val customMentorRepository: CustomMentorRepository
+    private val mentorRepository: MentorCustomRepository
 ) {
 
     /**
@@ -20,7 +20,7 @@ class QueryMentorListService(
      * @return 멘토 정보가 담긴 dto 리스트
      */
     fun execute(): List<MentorInfoDto> {
-        return customMentorRepository.findAllMentorInfoDto()
+        return mentorRepository.findAllMentorInfoDto()
     }
 
 }


### PR DESCRIPTION
## 개요
디스코드에서 말한대로 같은 기능을 하는 `Repository`를 두개 따로 두는것보단, 공통된것을 같이 두는게 나아 인터페이스를 만들고 `MentorRepository`에서 다중 상속을 하도록 구현하였습니다.

## 본문
`MentorCustomRepository`, `MentorCustomRepositoryImpl` 을 추가하였습니다.