### PR TITLE
MongoDB 의존성 추가 & Chat,Room 도메인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 
 	/* DB */
+	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 	implementation("mysql:mysql-connector-java:8.0.32")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -26,6 +26,7 @@ abstract class BaseChat(
     @Field(name = "roomId")
     @DocumentReference(lazy = true)
     open val room: ChatRoom,
-    open val content: String
+    open val content: Any,
+    open val type: ChatType
 ) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndexes
 import org.springframework.data.mongodb.core.mapping.Document
 import org.springframework.data.mongodb.core.mapping.DocumentReference
 import org.springframework.data.mongodb.core.mapping.Field
-import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+import team.themoment.gsmNetworking.domain.room.domain.Room
 import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
 
@@ -25,7 +25,7 @@ abstract class BaseChat(
     open val id: ObjectId,
     @Field(name = "roomId")
     @DocumentReference(lazy = true)
-    open val room: ChatRoom,
+    open val room: Room,
     open val content: BaseContent,
     open val type: ChatType
 ) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -26,7 +26,7 @@ abstract class BaseChat(
     @Field(name = "roomId")
     @DocumentReference(lazy = true)
     open val room: ChatRoom,
-    open val content: Any,
+    open val content: BaseContent,
     open val type: ChatType
 ) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -1,0 +1,31 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.DocumentReference
+import org.springframework.data.mongodb.core.mapping.Field
+import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
+
+@Document(collection = "chat")
+@CompoundIndexes(
+    CompoundIndex(
+        def = "{'roomId': -1, 'id': -1}",
+        name = "chat_roomId_id_compound_index",
+        unique = true
+    )
+)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+abstract class BaseChat(
+    @Id
+    open val id: ObjectId,
+    @Field(name = "roomId")
+    @DocumentReference(lazy = true)
+    open val room: ChatRoom,
+    open val content: String
+) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseContent.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseContent.kt
@@ -1,0 +1,3 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+abstract class BaseContent

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/ChatType.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/ChatType.kt
@@ -1,6 +1,7 @@
 package team.themoment.gsmNetworking.domain.chat.domain
 
-enum class ChatType {
-    USER,
-    SYSTEM
+enum class ChatType(clazz: Class<out BaseChat>) {
+    ALL(BaseChat::class.java),
+    USER(UserChat::class.java),
+    SYSTEM(SystemChat::class.java)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/ChatType.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/ChatType.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+enum class ChatType {
+    USER,
+    SYSTEM
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -10,6 +10,6 @@ import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
 class SystemChat(
     id: ObjectId = ObjectId.get(),
     room: ChatRoom,
-    content: String,
+    content: TextContent
 ) : BaseChat(id, room, content, ChatType.SYSTEM) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -10,7 +10,6 @@ import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
 class SystemChat(
     id: ObjectId,
     room: ChatRoom,
-    val senderId: Long,
     content: String,
 ) : BaseChat(id, room, content) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -11,5 +11,5 @@ class SystemChat(
     id: ObjectId = ObjectId.get(),
     room: Room,
     content: TextContent
-): BaseChat(id, room, content, ChatType.SYSTEM) {
+) : BaseChat(id, room, content, ChatType.SYSTEM) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -11,5 +11,5 @@ class SystemChat(
     id: ObjectId = ObjectId.get(),
     room: Room,
     content: TextContent
-) : BaseChat(id, room, content, ChatType.SYSTEM) {
+): BaseChat(id, room, content, ChatType.SYSTEM) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -8,7 +8,7 @@ import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
 @Document(collection = "chat")
 @TypeAlias("system")
 class SystemChat(
-    id: ObjectId,
+    id: ObjectId = ObjectId.get(),
     room: ChatRoom,
     content: String,
 ) : BaseChat(id, room, content, ChatType.SYSTEM) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -11,5 +11,5 @@ class SystemChat(
     id: ObjectId,
     room: ChatRoom,
     content: String,
-) : BaseChat(id, room, content) {
+) : BaseChat(id, room, content, ChatType.SYSTEM) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -3,13 +3,13 @@ package team.themoment.gsmNetworking.domain.chat.domain
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.TypeAlias
 import org.springframework.data.mongodb.core.mapping.Document
-import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+import team.themoment.gsmNetworking.domain.room.domain.Room
 
 @Document(collection = "chat")
 @TypeAlias("system")
 class SystemChat(
     id: ObjectId = ObjectId.get(),
-    room: ChatRoom,
+    room: Room,
     content: TextContent
 ) : BaseChat(id, room, content, ChatType.SYSTEM) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -1,0 +1,16 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.TypeAlias
+import org.springframework.data.mongodb.core.mapping.Document
+import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+
+@Document(collection = "chat")
+@TypeAlias("system")
+class SystemChat(
+    id: ObjectId,
+    room: ChatRoom,
+    val senderId: Long,
+    content: String,
+) : BaseChat(id, room, content) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/TextContent.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/TextContent.kt
@@ -1,0 +1,5 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+class TextContent(
+    val text: String
+): BaseContent()

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/TextContent.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/TextContent.kt
@@ -2,4 +2,4 @@ package team.themoment.gsmNetworking.domain.chat.domain
 
 class TextContent(
     val text: String
-): BaseContent()
+) : BaseContent()

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -11,6 +11,6 @@ class UserChat(
     id: ObjectId,
     room: ChatRoom,
     val senderId: Long,
-    content: String,
-) : BaseChat(id, room, content) {
+    content: String
+) : BaseChat(id, room, content, ChatType.USER) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -3,13 +3,13 @@ package team.themoment.gsmNetworking.domain.chat.domain
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.TypeAlias
 import org.springframework.data.mongodb.core.mapping.Document
-import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+import team.themoment.gsmNetworking.domain.room.domain.Room
 
 @Document(collection = "chat")
 @TypeAlias("user")
 class UserChat(
     id: ObjectId = ObjectId.get(),
-    room: ChatRoom,
+    room: Room,
     val senderId: Long,
     content: TextContent
 ) : BaseChat(id, room, content, ChatType.USER) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -12,5 +12,5 @@ class UserChat(
     room: Room,
     val senderId: Long,
     content: TextContent
-): BaseChat(id, room, content, ChatType.USER) {
+) : BaseChat(id, room, content, ChatType.USER) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -12,5 +12,5 @@ class UserChat(
     room: Room,
     val senderId: Long,
     content: TextContent
-) : BaseChat(id, room, content, ChatType.USER) {
+): BaseChat(id, room, content, ChatType.USER) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -1,0 +1,15 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.TypeAlias
+import org.springframework.data.mongodb.core.mapping.Document
+import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
+
+@Document(collection = "chat")
+@TypeAlias("user")
+class UserChat(
+    id: ObjectId,
+    room: ChatRoom,
+    content: String,
+) : BaseChat(id, room, content) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -11,6 +11,6 @@ class UserChat(
     id: ObjectId = ObjectId.get(),
     room: ChatRoom,
     val senderId: Long,
-    content: String
+    content: TextContent
 ) : BaseChat(id, room, content, ChatType.USER) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -8,7 +8,7 @@ import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
 @Document(collection = "chat")
 @TypeAlias("user")
 class UserChat(
-    id: ObjectId,
+    id: ObjectId = ObjectId.get(),
     room: ChatRoom,
     val senderId: Long,
     content: String

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -10,6 +10,7 @@ import team.themoment.gsmNetworking.domain.room.domain.ChatRoom
 class UserChat(
     id: ObjectId,
     room: ChatRoom,
+    val senderId: Long,
     content: String,
 ) : BaseChat(id, room, content) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ChatRoom.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ChatRoom.kt
@@ -1,0 +1,22 @@
+package team.themoment.gsmNetworking.domain.room.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.mapping.Document
+import java.util.*
+
+@Document(collection = "room")
+@CompoundIndexes(
+    CompoundIndex(
+        def = "{'userInfos.userId': 1, 'userInfos.lastViewedChatId': -1}",
+        name = "room_user_info_compound_index",
+        unique = true
+    )
+)
+class ChatRoom(
+    @Id
+    val id: UUID,
+    val name: String,
+    val userInfos: List<ChatUserInfo>
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ChatUserInfo.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ChatUserInfo.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.room.domain
+
+import org.bson.types.ObjectId
+
+data class ChatUserInfo(
+    val userId: Long,
+    val lastViewedChatId: ObjectId
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -14,7 +14,7 @@ import java.util.*
         unique = true
     )
 )
-class ChatRoom(
+class Room(
     @Id
     val id: UUID,
     val name: String,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,6 +20,12 @@ spring:
     username: root
     password: ${DB_LOCAL_PASSWORD}
 
+  data:
+    mongodb:
+      auto-index-creation: true
+      uri: mongodb://127.0.0.1:27017
+      database: gsm_networking
+
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
@@ -74,3 +80,14 @@ oauth2:
     success:
       sign-up-redirect-url: http://localhost:8080/signup
       default-redirect-url: http://localhost:8080/
+
+
+logging:
+  level:
+    org:
+      springframework:
+        data:
+          mongodb:
+            core:
+              index: DEBUG
+              MongoTemplate: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,13 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  data:
+    mongodb:
+      auto-index-creation: true
+      uri: ${MONGO_URL}
+      database: ${MONGO_DATABASE}
+      password: ${MONGO_PASSWORD}
+
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:


### PR DESCRIPTION
## 설명

채팅 서비스를 위한 `Chat`,`Room` 도메인을 구현하였습니다.
Chat,Room 도메인은 MongoDB에 저장됩니다.

MongoDB 의존성을 추가하고 관련 환경변수 설정을 적용하였습니다.

로컬 MongoDB 환경 구축 시에는 아래 링크를 참고해주세요.
https://poiemaweb.com/docker-mongodb

### 내용 추가
상속 방식이 복잡하기도 하고, 잘 다루기 어려워서 권장하는 구조는 아니라고 알고 있습니다.
https://www.inflearn.com/questions/30642/%EC%83%81%EC%86%8D%EA%B4%80%EA%B3%84-entity%EA%B0%84-%EC%A1%B0%EC%9D%B8

그럼에도 상속을 사용한 이유로는 다음과 같습니다.
- MongoDB를 사용하여 RDBMS와 달리 데이터 구조가 제한적이지 않습니다.
- 확장성이 더 좋습니다. 특히 앞으로 어떤 종류의 채팅이 추가되거나, 어떤 기능을 추가할 지 명확하지 않은 상황인만큼 확장성이 더 중요하다고 생각했습니다.