### PR TITLE
Room & Chat 엔티티, 레포지토리 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
@@ -2,7 +2,6 @@ package team.themoment.gsmNetworking
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 class GsmNetworkingApplication

--- a/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
-@EnableJpaAuditing
 class GsmNetworkingApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/GsmNetworkingApplication.kt
@@ -2,8 +2,10 @@ package team.themoment.gsmNetworking
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class GsmNetworkingApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -1,0 +1,38 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import java.time.LocalDateTime
+import javax.persistence.*
+
+
+@Entity(name = "chat")
+@EntityListeners(AuditingEntityListener::class)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type_num", discriminatorType = DiscriminatorType.INTEGER)
+abstract class BaseChat(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_id")
+    val id: Long = 0,
+
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    open val room: Room,
+
+    @Column(name = "content", nullable = false)
+    open val content: String,
+
+    // SystemChat 같이 sender가 없는 경우 Long.MAX_VALUE를 사용함
+    @Column(name = "sender_id", nullable = false)
+    val senderId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "chat_type", nullable = false)
+    open val type: ChatType
+) {
+    @CreatedDate
+    @Column(name = "create_at", nullable = false, updatable = false)
+    var createAt: LocalDateTime = LocalDateTime.MIN
+        protected set
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -8,6 +8,9 @@ import java.time.LocalDateTime
 import javax.persistence.*
 
 
+/**
+ * 채팅을 저장하는 Entity의 추상클래스입니다.
+ */
 @Entity(name = "chat")
 @EntityListeners(AuditingEntityListener::class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -5,6 +5,9 @@ import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import team.themoment.gsmNetworking.domain.room.domain.Room
 import javax.persistence.Entity
 
+/**
+ * 사용자 채팅을 저장하는 Entity 클래스입니다.
+ */
 @Entity
 @TypeAlias(ChatType.Alias.SYSTEM)
 class SystemChat(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -6,7 +6,7 @@ import team.themoment.gsmNetworking.domain.room.domain.Room
 import javax.persistence.Entity
 
 /**
- * 사용자 채팅을 저장하는 Entity 클래스입니다.
+ * 시스템 채팅을 저장하는 Entity 클래스입니다.
  */
 @Entity
 @TypeAlias(ChatType.Alias.SYSTEM)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -1,0 +1,15 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.springframework.data.annotation.TypeAlias
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import javax.persistence.Entity
+
+@Entity
+@TypeAlias(ChatType.Alias.SYSTEM)
+class SystemChat(
+    id: Long,
+    room: Room,
+    content: String,
+) : BaseChat(id, room, content, Long.MAX_VALUE, ChatType.SYSTEM) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -11,5 +11,11 @@ class SystemChat(
     id: Long,
     room: Room,
     content: String,
-) : BaseChat(id, room, content, Long.MAX_VALUE, ChatType.SYSTEM) {
+) : BaseChat(
+    id = id,
+    room = room,
+    content = content,
+    senderId = Long.MAX_VALUE,
+    type = ChatType.SYSTEM
+) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -12,5 +12,11 @@ class UserChat(
     room: Room,
     senderId: Long,
     content: String
-) : BaseChat(id, room, content, senderId, ChatType.USER) {
+) : BaseChat(
+    id = id,
+    room = room,
+    content = content,
+    senderId = senderId,
+    type = ChatType.USER
+) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -5,6 +5,9 @@ import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import team.themoment.gsmNetworking.domain.room.domain.Room
 import javax.persistence.Entity
 
+/**
+ * 사용자 채팅을 저장하는 Entity 클래스입니다.
+ */
 @Entity
 @TypeAlias(ChatType.Alias.USER)
 class UserChat(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -1,0 +1,16 @@
+package team.themoment.gsmNetworking.domain.chat.domain
+
+import org.springframework.data.annotation.TypeAlias
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import javax.persistence.Entity
+
+@Entity
+@TypeAlias(ChatType.Alias.USER)
+class UserChat(
+    id: Long,
+    room: Room,
+    senderId: Long,
+    content: String
+) : BaseChat(id, room, content, senderId, ChatType.USER) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/ChatType.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/ChatType.kt
@@ -1,0 +1,19 @@
+package team.themoment.gsmNetworking.domain.chat.enums
+
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.domain.chat.domain.SystemChat
+import team.themoment.gsmNetworking.domain.chat.domain.UserChat
+
+
+enum class ChatType(val clazz: Class<out BaseChat>) {
+    ALL(BaseChat::class.java),
+    USER(UserChat::class.java),
+    SYSTEM(SystemChat::class.java);
+
+    class Alias {
+        companion object {
+            const val USER = "1"
+            const val SYSTEM = "2"
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
@@ -1,0 +1,4 @@
+package team.themoment.gsmNetworking.domain.chat.repository
+
+interface ChatQueryRepository {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package team.themoment.gsmNetworking.domain.chat.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.baseChat
+import team.themoment.gsmNetworking.domain.chat.domain.QSystemChat.systemChat
+import team.themoment.gsmNetworking.domain.chat.domain.QUserChat.userChat
+
+class ChatQueryRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : ChatQueryRepository {
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatRepository.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.chat.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+
+interface ChatRepository : CrudRepository<BaseChat, Long>, ChatQueryRepository {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -1,0 +1,15 @@
+package team.themoment.gsmNetworking.domain.room.domain
+
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.index.Indexed
+import javax.persistence.*
+
+@RedisHash(value = "connected_room_user")
+class ConnectedRoomUser(
+    @Id
+    val roomId: Long,
+
+    @Indexed
+    val connectedUserId: Set<Long>
+) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -10,6 +10,6 @@ class ConnectedRoomUser(
     val roomId: Long,
 
     @Indexed
-    val connectedUserId: Set<Long>
+    val connectedUserIds: Set<Long>
 ) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -9,7 +9,6 @@ class ConnectedRoomUser(
     @Id
     val roomId: Long,
 
-    @Indexed
     val connectedUserIds: Set<Long>
 ) {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -1,11 +1,10 @@
 package team.themoment.gsmNetworking.domain.room.domain
 
 import org.springframework.data.redis.core.RedisHash
-import org.springframework.data.redis.core.index.Indexed
 import javax.persistence.*
 
 @RedisHash(value = "connected_room_user")
-class ConnectedRoomUser(
+data class ConnectedRoomUser(
     @Id
     val roomId: Long,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -3,6 +3,9 @@ package team.themoment.gsmNetworking.domain.room.domain
 import org.springframework.data.redis.core.RedisHash
 import javax.persistence.*
 
+/**
+ * 특정 [Room]에 접속 중인 사용자 정보를 저장하는 RedisHash 클래스입니다.
+ */
 @RedisHash(value = "connected_room_user")
 data class ConnectedRoomUser(
     @Id

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -1,0 +1,14 @@
+package team.themoment.gsmNetworking.domain.room.domain
+
+import javax.persistence.*
+
+@Entity(name = "room")
+class Room(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id")
+    val id: Long = 0,
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "room")
+    val roomUsers: List<RoomUser>
+) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -2,6 +2,9 @@ package team.themoment.gsmNetworking.domain.room.domain
 
 import javax.persistence.*
 
+/**
+ * 채팅방 정보를 저장하는 Entity 클래스입니다.
+ */
 @Entity(name = "room")
 class Room(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -3,6 +3,9 @@ package team.themoment.gsmNetworking.domain.room.domain
 import java.time.LocalDateTime
 import javax.persistence.*
 
+/**
+ * 채팅 방에서의 사용자 정보를 저장하는 엔티티 입니다.
+ */
 @Entity(name = "room_user")
 class RoomUser(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -1,0 +1,28 @@
+package team.themoment.gsmNetworking.domain.room.domain
+
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity(name = "room_user")
+class RoomUser(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_user_id")
+    val id: Long = 0,
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", referencedColumnName = "room_id")
+    val room: Room,
+
+    @Column(name = "room_name", unique = true)
+    val roomName: String,
+
+    // 결합도를 낮추기 위해 객체참조를 사용하지 않음 -- [우아한테크세미나] 우아한객체지향 1:04:00 ~ 1:18:00 참고
+    @Column(name = "user_id", unique = true)
+    val userId: Long,
+
+    @Column(name = "last_viewed_time", unique = true)
+    val lastViewedTime: LocalDateTime
+
+    //TODO 나중에 그룹채팅 기능 추가되면 방 권한도 추가
+) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -13,7 +13,7 @@ class RoomUser(
     @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     val room: Room,
 
-    @Column(name = "room_name", unique = true)
+    @Column(name = "room_name")
     val roomName: String,
 
     @Column(name = "user_id", unique = true)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -16,7 +16,6 @@ class RoomUser(
     @Column(name = "room_name", unique = true)
     val roomName: String,
 
-    // 결합도를 낮추기 위해 객체참조를 사용하지 않음 -- [우아한테크세미나] 우아한객체지향 1:04:00 ~ 1:18:00 참고
     @Column(name = "user_id", unique = true)
     val userId: Long,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/ConnectedRoomUserRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/ConnectedRoomUserRepository.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.room.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.room.domain.ConnectedRoomUser
+import team.themoment.gsmNetworking.domain.room.domain.Room
+
+interface ConnectedRoomUserRepository : CrudRepository<ConnectedRoomUser, Room> {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
@@ -1,0 +1,4 @@
+package team.themoment.gsmNetworking.domain.room.repository
+
+interface RoomQueryRepository {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.room.repository
+
+import team.themoment.gsmNetworking.domain.room.domain.QRoom.room
+import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+class RoomQueryRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : RoomQueryRepository {
+    
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomRepository.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.room.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.room.domain.Room
+
+interface RoomRepository : CrudRepository<Room, Long>, RoomQueryRepository {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomUserRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomUserRepository.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.room.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+
+interface RoomUserRepository : CrudRepository<RoomUser, Long> {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/config/EnableJpaAuditingConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/config/EnableJpaAuditingConfig.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class EnableJpaAuditingConfig


### PR DESCRIPTION
## 개요

Room과 Chat 도메인의 엔티티와 레포지토리를 구현하였습니다.

## 설명

#### Chat

Chat 도메인의 엔티티는 상속을 사용하여 확장성을 고려하였습니다.
추상 클래스 `BaseChat`을 구현한 `UserChat`, `SystemChat`이 존재합니다.

#### Room

`Room`은 채팅방 정보를 포함합니다.

#### RoomUser

User와 Room은 N:M 관계를 가지기 때문에 조인 엔티티`RoomUser`가 추가되었습니다.

`RoomUser`는 사용자와 채팅방 사이의 관계를 연결해주며, 채팅방 이름, 마지막으로 본 시간 등 추가적인 정보를 포함합니다.
또한 사용자와 다른 도메인이기 때문에 객체 참조를 사용하지 않았습니다.
참고 : [우아한 테크 세미나] 우아한 객체지향 1:04:00 ~ 1:18:00
https://www.youtube.com/watch?v=dJ5C4qRqAgA&t=4537s

또한, `RoomUser`는 `Room` 과 밀접한 관계가 있고, 따로 사용되는 일이 적을 것 같아 `RoomUserRepository`은 QueryDSL을 사용하지 않고 `CrudRepository`의 기능만 사용하려고 합니다.

#### ConnectedRoomUser
`ConnectedRoomUser`는 현재 채팅방에 접속한 사용자를 확인하며, 접속 여부에 따라 Socket 응답 or 알림(아직 구현계획 없음)이 실행됩니다.
