### PR TITLE
Chat/Room 도메인 엔티티 수정 및 Repository 메서드 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -11,7 +11,10 @@ import javax.persistence.*
 /**
  * 채팅을 저장하는 Entity의 추상클래스입니다.
  */
-@Entity(name = "chat")
+@Entity
+@Table(name = "chat", indexes = [
+    Index(name = "chat_idx_1", columnList = "room_id, create_at DESC, chat_id DESC"),
+])
 @EntityListeners(AuditingEntityListener::class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type_num", discriminatorType = DiscriminatorType.INTEGER)
@@ -21,6 +24,7 @@ abstract class BaseChat(
     val id: Long = 0,
 
     @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     open val room: Room,
 
     @Column(name = "content", nullable = false)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
@@ -1,0 +1,16 @@
+package team.themoment.gsmNetworking.domain.chat.dto.domain
+
+import org.springframework.data.annotation.CreatedDate
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import java.time.LocalDateTime
+import javax.persistence.*
+
+data class BaseChatDto(
+    val id: Long,
+    val room: Room,
+    val content: String,
+    val senderId: Long,
+    val type: ChatType,
+    var createAt: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.chat.dto.domain
+
+import java.time.LocalDateTime
+
+data class RecentChatQueryDto(
+    val roomId: Long,
+    val lastViewedTime: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/Direction.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/Direction.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.chat.enums
+
+enum class Direction {
+    UP,
+    DOWN
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
@@ -1,4 +1,13 @@
 package team.themoment.gsmNetworking.domain.chat.repository
 
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
+import team.themoment.gsmNetworking.domain.chat.enums.Direction
+import java.time.LocalDateTime
+
 interface ChatQueryRepository {
+    fun findChatsByTimeAndDirection(roomId: Long, direction: Direction, time: LocalDateTime, limit: Long): List<BaseChat>
+    fun findRecentChats(roomId: Long, limit: Long): List<BaseChat>
+    fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
@@ -1,12 +1,85 @@
 package team.themoment.gsmNetworking.domain.chat.repository
 
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
 import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.baseChat
-import team.themoment.gsmNetworking.domain.chat.domain.QSystemChat.systemChat
-import team.themoment.gsmNetworking.domain.chat.domain.QUserChat.userChat
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.enums.Direction
+import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
+import java.time.LocalDateTime
 
+/**
+ * Chat 쿼리 관련 레포지토리 [ChatQueryRepository]의 구현 클래스입니다.
+ */
 class ChatQueryRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : ChatQueryRepository {
 
+    /**
+     * 특정 방에서 지정된 방향과 시간을 기준으로 채팅 메시지를 검색합니다.
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param direction 채팅 메시지를 검색할 방향. [Direction.UP]인 경우 지정된 시간 **이전**의 Chat를 검색, [Direction.DOWN]인 경우 지정된 시간 **이후**의 Chat를 검색.
+     * @param time 검색의 기준이 되는 시간.
+     * @param limit 최대 반환 개수.
+     * @return 조건에 맞는 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
+     */
+    override fun findChatsByTimeAndDirection(
+        roomId: Long,
+        direction: Direction,
+        time: LocalDateTime,
+        limit: Long
+    ): List<BaseChat> {
+        val timeCondition = when (direction) {
+            Direction.UP -> baseChat.createAt.loe(time)
+            Direction.DOWN -> baseChat.createAt.goe(time)
+        }
+
+        return queryFactory
+            .select(baseChat)
+            .from(baseChat)
+            .where(baseChat.room.id.eq(roomId).and(timeCondition))
+            .orderBy(baseChat.createAt.desc(), baseChat.id.desc())
+            .limit(limit)
+            .fetch()
+            .sortedWith(compareBy({ it.createAt }, { it.id }))
+    }
+
+    /**
+     * 특정 방에서 최근 채팅 메시지를 검색합니다.
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param limit 최대 반환 개수.
+     * @return 최근 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
+     */
+    override fun findRecentChats(roomId: Long, limit: Long): List<BaseChat> =
+        findChatsByTimeAndDirection(roomId, Direction.UP, LocalDateTime.MAX, limit)
+
+    /**
+     * 특정 방들의 최근 채팅 메시지를 가져옵니다.
+     *
+     * @param roomInfos
+     * @param limit 최대 반환 개수.
+     * @return 최근 채팅 메시지 목록. 시간, ID 순으로 오름차순 정렬되어 반환
+     */
+    override fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto> {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    BaseChatDto::class.java,
+                    baseChat.id,
+                    baseChat.room,
+                    baseChat.content,
+                    baseChat.senderId,
+                    baseChat.type,
+                    baseChat.createAt
+                )
+            )
+            .from(baseChat)
+            .where(baseChat.room.id.`in`(roomInfos.map { it.roomId }))
+            .orderBy(baseChat.createAt.desc(), baseChat.createAt.desc())
+            .limit(limit)
+            .fetch()
+    }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -5,7 +5,8 @@ import javax.persistence.*
 /**
  * 채팅방 정보를 저장하는 Entity 클래스입니다.
  */
-@Entity(name = "room")
+@Entity
+@Table(name = "room")
 class Room(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_id")

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -6,7 +6,15 @@ import javax.persistence.*
 /**
  * 채팅 방에서의 사용자 정보를 저장하는 엔티티 입니다.
  */
-@Entity(name = "room_user")
+@Entity
+@Table(
+    name = "room_user", indexes = [
+        Index(
+            name = "room_user_idx_1",
+            columnList = "user_id, room_id, last_viewed_time DESC"
+        )
+    ]
+)
 class RoomUser(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_user_id")
@@ -16,13 +24,13 @@ class RoomUser(
     @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     val room: Room,
 
-    @Column(name = "room_name")
+    @Column(name = "room_name", nullable = false)
     val roomName: String,
 
-    @Column(name = "user_id", unique = true)
+    @Column(name = "user_id", nullable = false)
     val userId: Long,
 
-    @Column(name = "last_viewed_time", unique = true)
+    @Column(name = "last_viewed_time", nullable = false)
     val lastViewedTime: LocalDateTime
 
     //TODO 나중에 그룹채팅 기능 추가되면 방 권한도 추가

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.room.dto.domain
+
+import java.time.LocalDateTime
+
+data class RoomUserDto(
+    val id: Long,
+    val userId: Long,
+    val roomId: Long,
+    val roomName: String,
+    val lastViewedTime: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
@@ -1,4 +1,11 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
+
 interface RoomQueryRepository {
+    fun findRoomUserOrNull(userId: Long, roomId: Long): RoomUser?
+    fun findRoomsRecentUpdated(userId: Long, pageable: Pageable): Page<RoomUserDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -1,11 +1,110 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
-import team.themoment.gsmNetworking.domain.room.domain.QRoom.room
-import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat
+import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.*
+import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 
+/**
+ * Room 쿼리 관련 레포지토리 [RoomQueryRepository]의 구현 클래스입니다.
+ */
 class RoomQueryRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : RoomQueryRepository {
-    
+
+    /**
+     * 특정 사용자의 특정 방에 대한 정보를 검색합니다.
+     *
+     * @param userId 채팅 정보를 검색할 사용자의 고유 식별자
+     * @param roomId 채팅 정보를 검색할 방의 고유 식별자
+     * @return 해당 사용자의 해당 방에 대한 정보 (존재하지 않으면 null 반환)
+     */
+    override fun findRoomUserOrNull(
+        userId: Long,
+        roomId: Long
+    ): RoomUser? {
+        return queryFactory
+            .select(roomUser)
+            .from(roomUser)
+            .on(
+                roomUser.userId.eq(userId),
+                roomUser.room.id.eq(roomId)
+            )
+            .orderBy(roomUser.lastViewedTime.desc())
+            .fetchFirst()
+    }
+
+    /**
+     * 사용자의 최근 업데이트된 방 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param userId 방 목록을 조회할 사용자의 고유 식별자
+     * @param pageable 페이지 정보 (페이지 번호, 페이지 크기 등)
+     * @return 방 목록과 페이지에 대한 정보
+     */
+    override fun findRoomsRecentUpdated(userId: Long, pageable: Pageable): Page<RoomUserDto> {
+        val rooms = findRoomsByUserId(userId, pageable)
+        val total = findCountUserRooms(userId)
+
+        return PageImpl(rooms, pageable, total)
+    }
+
+    /**
+     * 특정 사용자의 최근 채팅을 기준으로 방 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param userId 방 목록을 조회할 사용자의 고유 식별자
+     * @param pageable 페이지 정보 (페이지 번호, 페이지 크기 등)
+     * @return 방 목록
+     */
+    private fun findRoomsByUserId(userId: Long, pageable: Pageable): List<RoomUserDto> {
+        val subBaseChat = QBaseChat("subBaseChat")
+        val getResentChatIdSubQuery = JPAExpressions
+            .select(subBaseChat.id)
+            .from(subBaseChat)
+            .where(subBaseChat.room.id.eq(roomUser.room.id))
+            .orderBy(subBaseChat.createAt.desc(), subBaseChat.id.desc())
+            .limit(1)
+
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    RoomUserDto::class.java,
+                    roomUser.userId,
+                    roomUser.room.id,
+                    roomUser.roomName,
+                    roomUser.lastViewedTime
+                )
+            )
+            .from(roomUser)
+            .innerJoin(baseChat)
+            .on(
+                roomUser.userId.eq(userId),
+                baseChat.room.id.eq(getResentChatIdSubQuery),
+                baseChat.room.id.eq(roomUser.room.id)
+            )
+            .orderBy(baseChat.createAt.desc(), baseChat.id.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+    }
+
+    /**
+     * 특정 사용자의 방 개수를 조회합니다.
+     *
+     * @param userId 방 개수를 조회할 사용자의 고유 식별자
+     * @return 해당 사용자의 방 개수
+     */
+    private fun findCountUserRooms(userId: Long): Long {
+        return queryFactory
+            .select(roomUser.count())
+            .from(roomUser)
+            .where(roomUser.userId.eq(userId))
+            .fetchFirst() // fetchFirst or fetchOne - 집계함수를 사용하기 때문에 무조건 1 개의 row를 반환한다는 점에선 fetchOne이 맞는거 같은데, 잘 모르겠음 이 경우 nullable 처리를 어떻게 해야 하나? 잘 모르겠음
+    }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -105,6 +105,6 @@ class RoomQueryRepositoryImpl(
             .select(roomUser.count())
             .from(roomUser)
             .where(roomUser.userId.eq(userId))
-            .fetchFirst() // fetchFirst or fetchOne - 집계함수를 사용하기 때문에 무조건 1 개의 row를 반환한다는 점에선 fetchOne이 맞는거 같은데, 잘 모르겠음 이 경우 nullable 처리를 어떻게 해야 하나? 잘 모르겠음
+            .fetchFirst()
     }
 }


### PR DESCRIPTION
## 개요
Chat/Room 도메인 엔티티를 수정하고, Repository 메서드를 구현하였습니다.

## 설명
### Chat/Room 도메인 변경사항
1. 인덱스 설정 추가
2. 테이블 이름을 `@Entity` 대신 `@Table` 에서 정의하도록 변경
3. 일부 잘못된 `@Column` 설정 변경

### Repository 메서드 구현
chat 서비스에 사용되는 Query 메서드를 구현하였습니다.
앞으로 더 추가될 수도 있지만, 주로 사용할 복잡한 쿼리는 이 PR에 구현되어있습니다.

## 피드백 요청
`RoomQueryRepositoryImpl#findCountUserRooms` 가 무조건 long 타입 숫자 하나만 반환하는데,(2이상, 0은 불가능) 
그럼 `fetchFirst` 대신 `fetchOne`을 사용하는게 좋을까요?
(해당 내용 관련된 주석이 실수로 지워지지 않았는데, 수정하도록 하겠습니다.)

그리고 `fetchOne`을 사용하는 경우 반환 타입이 `Long?` 인데, 어느 단에서 예외처리를 하는게 적절할까요.
사용하는 쿼리 특성 상 `RoomQueryRepositoryImpl#findCountUserRooms` 내부에서 `!!` 을 사용할지, 외부에서 `?:` 을 사용할지 고민입니다.
