### PR TITLE
Chat/Room 도메인 엔티티 수정 및 Repository 메서드 구현 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 
 	/* DB */
+	implementation ("com.fasterxml.uuid:java-uuid-generator:4.1.1")
 	implementation("mysql:mysql-connector-java:8.0.32")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -48,7 +48,7 @@ class UUIDUtils {
         }
 
         /**
-         * 주어진 UUID에서 시잔 정보를 반환합니다.
+         * 주어진 UUID에서 시간 정보를 반환합니다.
          *
          * @param uuid epoch 밀리초를 추출할 UUID
          * @return UUID에서 추출된 시간 정보, LocalDateTime 타입
@@ -71,7 +71,7 @@ class UUIDUtils {
         }
 
         /**
-         * 주어진 UUID에서 시잔 정보를 반환합니다.
+         * 주어진 UUID에서 시간 정보를 반환합니다.
          *
          * @param uuid epoch 밀리초를 추출할 UUID
          * @return UUID에서 추출된 시간 정보, Instant 타입

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -1,0 +1,48 @@
+package team.themoment.gsmNetworking.common.util
+
+import java.time.*
+import java.util.*
+
+class UUIDUtils {
+    companion object {
+        private const val UUID_FORMAT = "%012x-7000-0000-000000000000"
+        private const val MAX_EPOCH_MILLIS = 95649119999000L // 5000-12-31 23:59:59 GMT
+        private const val MIN_EPOCH_MILLIS = 0L // 1970-1-1 00:00:00 GMT
+
+        val MAX_TIME: Instant = Instant.ofEpochMilli(MAX_EPOCH_MILLIS)
+        val MIN_TIME: Instant = Instant.ofEpochMilli(MIN_EPOCH_MILLIS)
+
+        private fun generateUUIDv7FromEpochMilli(epochMilli: Long): UUID {
+            val hex = String.format(UUID_FORMAT, epochMilli).replaceRange(8, 8, "-")
+            return UUID.fromString(hex)
+        }
+
+        fun generateSmallestUUIDv7(time: LocalDateTime): UUID {
+            val epochMilli = getEpochMilli(time)
+            return generateUUIDv7FromEpochMilli(epochMilli)
+        }
+
+        fun generateSmallestUUIDv7(instant: Instant): UUID {
+            val epochMilli = instant.toEpochMilli()
+            return generateUUIDv7FromEpochMilli(epochMilli)
+        }
+
+        fun getTime(uuid: UUID): LocalDateTime {
+            return Instant.ofEpochMilli(getEpochMilli(uuid))
+                .atZone(ZoneId.systemDefault()).toLocalDateTime()
+        }
+
+        fun getEpochMilli(uuid: UUID): Long {
+            return uuid.mostSignificantBits ushr 16
+        }
+
+        fun getInstant(uuid: UUID): Instant {
+            val milliseconds = getEpochMilli(uuid)
+            return Instant.ofEpochMilli(milliseconds)
+        }
+
+        fun getEpochMilli(time: LocalDateTime): Long {
+            return time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -19,7 +19,7 @@ class UUIDUtils {
          */
         private fun generateSmallestUUIDv7(epochMilli: Long): UUID {
             // 지정된 위치에 '-'를 삽입하여 포맷된 UUID 문자열을 생성합니다.
-            // 결과적으로 형식은 "xxxxxxxx-7000-0000-000000000000"와 같습니다.
+            // 결과적으로 형식은 "xxxxxxxx-xxxx-7000-0000-000000000000"와 같습니다.
             val hex = String.format("%012x-7000-0000-000000000000", epochMilli)
                 .replaceRange(8, 8, "-")
             return UUID.fromString(hex)

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -5,43 +5,89 @@ import java.util.*
 
 class UUIDUtils {
     companion object {
-        private const val UUID_FORMAT = "%012x-7000-0000-000000000000"
         private const val MAX_EPOCH_MILLIS = 95649119999000L // 5000-12-31 23:59:59 GMT
         private const val MIN_EPOCH_MILLIS = 0L // 1970-1-1 00:00:00 GMT
 
         val MAX_TIME: Instant = Instant.ofEpochMilli(MAX_EPOCH_MILLIS)
         val MIN_TIME: Instant = Instant.ofEpochMilli(MIN_EPOCH_MILLIS)
 
-        private fun generateUUIDv7FromEpochMilli(epochMilli: Long): UUID {
-            val hex = String.format(UUID_FORMAT, epochMilli).replaceRange(8, 8, "-")
+        /**
+         * 주어진 epoch 밀리초를 사용하여 가장 작은 v7 UUID를 생성합니다.
+         *
+         * @param epochMilli 특정 시간을 나타내는 epoch 밀리초 값입니다.
+         * @return epoch 밀리초에서 생성된 가장 작은 v7 UUID입니다.
+         */
+        private fun generateSmallestUUIDv7(epochMilli: Long): UUID {
+            // 지정된 위치에 '-'를 삽입하여 포맷된 UUID 문자열을 생성합니다.
+            // 결과적으로 형식은 "xxxxxxxx-7000-0000-000000000000"와 같습니다.
+            val hex = String.format("%012x-7000-0000-000000000000", epochMilli)
+                .replaceRange(8, 8, "-")
             return UUID.fromString(hex)
         }
 
+        /**
+         * 가장 작은 v7 UUID를 생성합니다.
+         *
+         * @param time 변환할 LocalDateTime 객체
+         * @return epoch 밀리초 값
+         */
         fun generateSmallestUUIDv7(time: LocalDateTime): UUID {
             val epochMilli = getEpochMilli(time)
-            return generateUUIDv7FromEpochMilli(epochMilli)
+            return generateSmallestUUIDv7(epochMilli)
         }
 
+        /**
+         * 가장 작은 v7 UUID를 생성합니다.
+         *
+         * @param time 변환할 Instant 객체
+         * @return epoch 밀리초 값
+         */
         fun generateSmallestUUIDv7(instant: Instant): UUID {
             val epochMilli = instant.toEpochMilli()
-            return generateUUIDv7FromEpochMilli(epochMilli)
+            return generateSmallestUUIDv7(epochMilli)
         }
 
+        /**
+         * 주어진 UUID에서 시잔 정보를 반환합니다.
+         *
+         * @param uuid epoch 밀리초를 추출할 UUID
+         * @return UUID에서 추출된 시간 정보, LocalDateTime 타입
+         */
         fun getTime(uuid: UUID): LocalDateTime {
             return Instant.ofEpochMilli(getEpochMilli(uuid))
                 .atZone(ZoneId.systemDefault()).toLocalDateTime()
         }
 
+        /**
+         * 주어진 UUID에서 epoch 밀리초를 추출합니다.
+         *
+         * @param uuid epoch 밀리초를 추출할 UUID
+         * @return UUID에서 추출된 epoch 밀리초
+         */
         fun getEpochMilli(uuid: UUID): Long {
+            // v7 UUID는 타임스탬프 정보가 Most Significant Bits(총 48bit) 중 앞 36bit에 저장됩니다.
+            // MSB를 오른쪽으로 16bit 시프트하여 타임스탬프를 추출합니다.
             return uuid.mostSignificantBits ushr 16
         }
 
+        /**
+         * 주어진 UUID에서 시잔 정보를 반환합니다.
+         *
+         * @param uuid epoch 밀리초를 추출할 UUID
+         * @return UUID에서 추출된 시간 정보, Instant 타입
+         */
         fun getInstant(uuid: UUID): Instant {
             val milliseconds = getEpochMilli(uuid)
             return Instant.ofEpochMilli(milliseconds)
         }
 
-        fun getEpochMilli(time: LocalDateTime): Long {
+        /**
+         * LocalDateTime 객체에서 epoch 밀리초를 추출합니다.
+         *
+         * @param time 변환할 LocalDateTime 객체
+         * @return epoch 밀리초 값
+         */
+        private fun getEpochMilli(time: LocalDateTime): Long {
             return time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
         }
     }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -1,10 +1,10 @@
 package team.themoment.gsmNetworking.domain.chat.domain
 
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import team.themoment.gsmNetworking.common.util.UUIDUtils
 import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import team.themoment.gsmNetworking.domain.room.domain.Room
-import java.time.LocalDateTime
+import java.time.Instant
+import java.util.*
 import javax.persistence.*
 
 
@@ -13,15 +13,14 @@ import javax.persistence.*
  */
 @Entity
 @Table(name = "chat", indexes = [
-    Index(name = "chat_idx_1", columnList = "room_id, create_at DESC, chat_id DESC"),
+    Index(name = "chat_idx_1", columnList = "room_id, chat_id DESC"),
 ])
-@EntityListeners(AuditingEntityListener::class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type_num", discriminatorType = DiscriminatorType.INTEGER)
 abstract class BaseChat(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "chat_id")
-    val id: Long = 0,
+    @Id
+    @Column(name = "chat_id", columnDefinition = "BINARY(16)")
+    val id: UUID,
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", referencedColumnName = "room_id")
@@ -36,10 +35,8 @@ abstract class BaseChat(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "chat_type", nullable = false)
-    open val type: ChatType
+    open val type: ChatType,
 ) {
-    @CreatedDate
-    @Column(name = "create_at", nullable = false, updatable = false)
-    var createAt: LocalDateTime = LocalDateTime.MIN
-        protected set
+    val createAt: Instant
+        get() = UUIDUtils.getInstant(id)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -23,7 +23,7 @@ abstract class BaseChat(
     @Column(name = "chat_id")
     val id: Long = 0,
 
-    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     open val room: Room,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/BaseChat.kt
@@ -11,7 +11,10 @@ import javax.persistence.*
 /**
  * 채팅을 저장하는 Entity의 추상클래스입니다.
  */
-@Entity(name = "chat")
+@Entity
+@Table(name = "chat", indexes = [
+    Index(name = "chat_idx_1", columnList = "room_id, create_at DESC, chat_id DESC"),
+])
 @EntityListeners(AuditingEntityListener::class)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type_num", discriminatorType = DiscriminatorType.INTEGER)
@@ -21,6 +24,7 @@ abstract class BaseChat(
     val id: Long = 0,
 
     @OneToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     open val room: Room,
 
     @Column(name = "content", nullable = false)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/SystemChat.kt
@@ -1,8 +1,10 @@
 package team.themoment.gsmNetworking.domain.chat.domain
 
+import com.fasterxml.uuid.Generators
 import org.springframework.data.annotation.TypeAlias
 import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import team.themoment.gsmNetworking.domain.room.domain.Room
+import java.util.UUID
 import javax.persistence.Entity
 
 /**
@@ -11,7 +13,7 @@ import javax.persistence.Entity
 @Entity
 @TypeAlias(ChatType.Alias.SYSTEM)
 class SystemChat(
-    id: Long,
+    id: UUID = Generators.timeBasedEpochGenerator().generate(),
     room: Room,
     content: String,
 ) : BaseChat(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/domain/UserChat.kt
@@ -1,8 +1,10 @@
 package team.themoment.gsmNetworking.domain.chat.domain
 
+import com.fasterxml.uuid.Generators
 import org.springframework.data.annotation.TypeAlias
 import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import team.themoment.gsmNetworking.domain.room.domain.Room
+import java.util.UUID
 import javax.persistence.Entity
 
 /**
@@ -11,7 +13,7 @@ import javax.persistence.Entity
 @Entity
 @TypeAlias(ChatType.Alias.USER)
 class UserChat(
-    id: Long,
+    id: UUID = Generators.timeBasedEpochGenerator().generate(),
     room: Room,
     senderId: Long,
     content: String

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
@@ -1,0 +1,16 @@
+package team.themoment.gsmNetworking.domain.chat.dto.domain
+
+import org.springframework.data.annotation.CreatedDate
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import java.time.LocalDateTime
+import javax.persistence.*
+
+data class BaseChatDto(
+    val id: Long,
+    val room: Room,
+    val content: String,
+    val senderId: Long,
+    val type: ChatType,
+    var createAt: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/BaseChatDto.kt
@@ -1,16 +1,16 @@
 package team.themoment.gsmNetworking.domain.chat.dto.domain
 
-import org.springframework.data.annotation.CreatedDate
 import team.themoment.gsmNetworking.domain.chat.enums.ChatType
-import team.themoment.gsmNetworking.domain.room.domain.Room
-import java.time.LocalDateTime
-import javax.persistence.*
+import java.util.*
 
 data class BaseChatDto(
-    val id: Long,
-    val room: Room,
+    val id: UUID,
+    val room: RoomInfo,
     val content: String,
     val senderId: Long,
-    val type: ChatType,
-    var createAt: LocalDateTime
-)
+    val type: ChatType
+) {
+    data class RoomInfo(
+        val id: Long
+    )
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
@@ -1,8 +1,0 @@
-package team.themoment.gsmNetworking.domain.chat.dto.domain
-
-import java.time.LocalDateTime
-
-data class RecentChatQueryDto(
-    val roomId: Long,
-    val lastViewedTime: LocalDateTime
-)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/domain/RecentChatQueryDto.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.chat.dto.domain
+
+import java.time.LocalDateTime
+
+data class RecentChatQueryDto(
+    val roomId: Long,
+    val lastViewedTime: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/Direction.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/enums/Direction.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.chat.enums
+
+enum class Direction {
+    UP,
+    DOWN
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
@@ -1,4 +1,13 @@
 package team.themoment.gsmNetworking.domain.chat.repository
 
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
+import team.themoment.gsmNetworking.domain.chat.enums.Direction
+import java.time.LocalDateTime
+
 interface ChatQueryRepository {
+    fun findChatsByTimeAndDirection(roomId: Long, direction: Direction, time: LocalDateTime, limit: Long): List<BaseChat>
+    fun findRecentChats(roomId: Long, limit: Long): List<BaseChat>
+    fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepository.kt
@@ -1,13 +1,37 @@
 package team.themoment.gsmNetworking.domain.chat.repository
 
-import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
 import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
-import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
 import team.themoment.gsmNetworking.domain.chat.enums.Direction
-import java.time.LocalDateTime
+import java.time.Instant
 
+/**
+ * [Chat]에 대한 쿼리 기능을 제공하는 리포지토리입니다.
+ */
 interface ChatQueryRepository {
-    fun findChatsByTimeAndDirection(roomId: Long, direction: Direction, time: LocalDateTime, limit: Long): List<BaseChat>
-    fun findRecentChats(roomId: Long, limit: Long): List<BaseChat>
-    fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto>
+
+    /**
+     * 특정 방에서 지정된 방향과 시간을 기준으로 채팅 메시지를 검색합니다.
+     *
+     * ```
+     * time param 값에 따라 방향이 결정
+     *  - [Direction.UP]인 경우 지정된 시간 이전의 채팅을 검색 (요청에 사용된 시간 포함)
+     *  - [Direction.DOWN]인 경우 지정된 시간 이후의 채팅을 검색 (요청에 사용된 시간 포함)
+     * ```
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param direction 채팅 메시지를 검색할 방향.
+     * @param time 검색의 기준이 되는 시간.
+     * @param limit 최대 반환 개수.
+     * @return 조건에 맞는 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환됩니다.
+     */
+    fun findChatsByTimeAndDirection(roomId: Long, direction: Direction, time: Instant, limit: Long): List<BaseChatDto>
+
+    /**
+     * 특정 방에서 최근 채팅 메시지를 검색합니다.
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param limit 최대 반환 개수.
+     * @return 최근 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환됩니다.
+     */
+    fun findRecentChats(roomId: Long, limit: Long): List<BaseChatDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
@@ -1,12 +1,85 @@
 package team.themoment.gsmNetworking.domain.chat.repository
 
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
 import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.baseChat
-import team.themoment.gsmNetworking.domain.chat.domain.QSystemChat.systemChat
-import team.themoment.gsmNetworking.domain.chat.domain.QUserChat.userChat
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.enums.Direction
+import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
+import java.time.LocalDateTime
 
+/**
+ * Chat 쿼리 관련 레포지토리 [ChatQueryRepository]의 구현 클래스입니다.
+ */
 class ChatQueryRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : ChatQueryRepository {
 
+    /**
+     * 특정 방에서 지정된 방향과 시간을 기준으로 채팅 메시지를 검색합니다.
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param direction 채팅 메시지를 검색할 방향. [Direction.UP]인 경우 지정된 시간 **이전**의 Chat를 검색, [Direction.DOWN]인 경우 지정된 시간 **이후**의 Chat를 검색.
+     * @param time 검색의 기준이 되는 시간.
+     * @param limit 최대 반환 개수.
+     * @return 조건에 맞는 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
+     */
+    override fun findChatsByTimeAndDirection(
+        roomId: Long,
+        direction: Direction,
+        time: LocalDateTime,
+        limit: Long
+    ): List<BaseChat> {
+        val timeCondition = when (direction) {
+            Direction.UP -> baseChat.createAt.loe(time)
+            Direction.DOWN -> baseChat.createAt.goe(time)
+        }
+
+        return queryFactory
+            .select(baseChat)
+            .from(baseChat)
+            .where(baseChat.room.id.eq(roomId).and(timeCondition))
+            .orderBy(baseChat.createAt.desc(), baseChat.id.desc())
+            .limit(limit)
+            .fetch()
+            .sortedWith(compareBy({ it.createAt }, { it.id }))
+    }
+
+    /**
+     * 특정 방에서 최근 채팅 메시지를 검색합니다.
+     *
+     * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
+     * @param limit 최대 반환 개수.
+     * @return 최근 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
+     */
+    override fun findRecentChats(roomId: Long, limit: Long): List<BaseChat> =
+        findChatsByTimeAndDirection(roomId, Direction.UP, LocalDateTime.MAX, limit)
+
+    /**
+     * 특정 방들의 최근 채팅 메시지를 가져옵니다.
+     *
+     * @param roomInfos
+     * @param limit 최대 반환 개수.
+     * @return 최근 채팅 메시지 목록. 시간, ID 순으로 오름차순 정렬되어 반환
+     */
+    override fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto> {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    BaseChatDto::class.java,
+                    baseChat.id,
+                    baseChat.room,
+                    baseChat.content,
+                    baseChat.senderId,
+                    baseChat.type,
+                    baseChat.createAt
+                )
+            )
+            .from(baseChat)
+            .where(baseChat.room.id.`in`(roomInfos.map { it.roomId }))
+            .orderBy(baseChat.createAt.desc(), baseChat.createAt.desc())
+            .limit(limit)
+            .fetch()
+    }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/repository/ChatQueryRepositoryImpl.kt
@@ -2,12 +2,11 @@ package team.themoment.gsmNetworking.domain.chat.repository
 
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
-import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.common.util.UUIDUtils
 import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.baseChat
 import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
 import team.themoment.gsmNetworking.domain.chat.enums.Direction
-import team.themoment.gsmNetworking.domain.chat.dto.domain.RecentChatQueryDto
-import java.time.LocalDateTime
+import java.time.*
 
 /**
  * Chat 쿼리 관련 레포지토리 [ChatQueryRepository]의 구현 클래스입니다.
@@ -19,8 +18,14 @@ class ChatQueryRepositoryImpl(
     /**
      * 특정 방에서 지정된 방향과 시간을 기준으로 채팅 메시지를 검색합니다.
      *
+     * ```
+     * time param 값에 따라 방향이 결정
+     * [Direction.UP]인 경우 지정된 시간 **이전**의 Chat를 검색 (저징된 시간 포함)
+     * [Direction.DOWN]인 경우 지정된 시간 **이후**의 Chat를 검색 (저징된 시간 포함)
+     * ```
+     *
      * @param roomId 채팅 메시지를 검색할 방의 고유 식별자.
-     * @param direction 채팅 메시지를 검색할 방향. [Direction.UP]인 경우 지정된 시간 **이전**의 Chat를 검색, [Direction.DOWN]인 경우 지정된 시간 **이후**의 Chat를 검색.
+     * @param direction 채팅 메시지를 검색할 방향.
      * @param time 검색의 기준이 되는 시간.
      * @param limit 최대 반환 개수.
      * @return 조건에 맞는 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
@@ -28,22 +33,34 @@ class ChatQueryRepositoryImpl(
     override fun findChatsByTimeAndDirection(
         roomId: Long,
         direction: Direction,
-        time: LocalDateTime,
+        time: Instant,
         limit: Long
-    ): List<BaseChat> {
+    ): List<BaseChatDto> {
         val timeCondition = when (direction) {
-            Direction.UP -> baseChat.createAt.loe(time)
-            Direction.DOWN -> baseChat.createAt.goe(time)
+            // 입력받은 시간 + 1을 미만 조건으로 검색
+            Direction.UP -> baseChat.id.lt(UUIDUtils.generateSmallestUUIDv7(time.plusMillis(1)))
+            Direction.DOWN -> baseChat.id.goe(UUIDUtils.generateSmallestUUIDv7(time))
         }
 
         return queryFactory
-            .select(baseChat)
+            .select(
+                Projections.constructor(
+                    BaseChatDto::class.java,
+                    baseChat.id,
+                    Projections.constructor(
+                        BaseChatDto.RoomInfo::class.java,
+                        baseChat.room.id
+                    ),
+                    baseChat.content,
+                    baseChat.senderId,
+                    baseChat.type
+                )
+            )
             .from(baseChat)
             .where(baseChat.room.id.eq(roomId).and(timeCondition))
-            .orderBy(baseChat.createAt.desc(), baseChat.id.desc())
+            .orderBy(baseChat.id.desc())
             .limit(limit)
             .fetch()
-            .sortedWith(compareBy({ it.createAt }, { it.id }))
     }
 
     /**
@@ -53,33 +70,6 @@ class ChatQueryRepositoryImpl(
      * @param limit 최대 반환 개수.
      * @return 최근 채팅 메시지 목록. 시간순으로 내림차순으로 정렬되어 반환.
      */
-    override fun findRecentChats(roomId: Long, limit: Long): List<BaseChat> =
-        findChatsByTimeAndDirection(roomId, Direction.UP, LocalDateTime.MAX, limit)
-
-    /**
-     * 특정 방들의 최근 채팅 메시지를 가져옵니다.
-     *
-     * @param roomInfos
-     * @param limit 최대 반환 개수.
-     * @return 최근 채팅 메시지 목록. 시간, ID 순으로 오름차순 정렬되어 반환
-     */
-    override fun findRoomsRecentChats(roomInfos: List<RecentChatQueryDto>, limit: Long): List<BaseChatDto> {
-        return queryFactory
-            .select(
-                Projections.constructor(
-                    BaseChatDto::class.java,
-                    baseChat.id,
-                    baseChat.room,
-                    baseChat.content,
-                    baseChat.senderId,
-                    baseChat.type,
-                    baseChat.createAt
-                )
-            )
-            .from(baseChat)
-            .where(baseChat.room.id.`in`(roomInfos.map { it.roomId }))
-            .orderBy(baseChat.createAt.desc(), baseChat.createAt.desc())
-            .limit(limit)
-            .fetch()
-    }
+    override fun findRecentChats(roomId: Long, limit: Long): List<BaseChatDto> =
+        findChatsByTimeAndDirection(roomId, Direction.UP, UUIDUtils.MAX_TIME, limit)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/ConnectedRoomUser.kt
@@ -1,7 +1,7 @@
 package team.themoment.gsmNetworking.domain.room.domain
 
+import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
-import javax.persistence.*
 
 /**
  * 특정 [Room]에 접속 중인 사용자 정보를 저장하는 RedisHash 클래스입니다.

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -12,6 +12,7 @@ class Room(
     @Column(name = "room_id")
     val id: Long = 0,
 
+    // RoomUser Room을 사용하는 많은 상황에서 필요하면 EAGER로 변경하기
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "room")
     val roomUsers: List<RoomUser>
 ) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/Room.kt
@@ -5,7 +5,8 @@ import javax.persistence.*
 /**
  * 채팅방 정보를 저장하는 Entity 클래스입니다.
  */
-@Entity(name = "room")
+@Entity
+@Table(name = "room")
 class Room(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_id")

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -1,6 +1,8 @@
 package team.themoment.gsmNetworking.domain.room.domain
 
-import java.time.LocalDateTime
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import java.time.Instant
+import java.util.UUID
 import javax.persistence.*
 
 /**
@@ -11,7 +13,11 @@ import javax.persistence.*
     name = "room_user", indexes = [
         Index(
             name = "room_user_idx_1",
-            columnList = "user_id, room_id, last_viewed_time DESC"
+            columnList = "user_id, recent_chat_id DESC"
+        ),
+        Index(
+            name = "room_user_idx_2",
+            columnList = "room_id, user_id"
         )
     ]
 )
@@ -30,9 +36,14 @@ class RoomUser(
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 
-    @Column(name = "last_viewed_time", nullable = false)
-    val lastViewedTime: LocalDateTime
+    @Column(name = "last_viewed_chat_id", nullable = false, columnDefinition = "BINARY(16)")
+    val lastViewedChatId: UUID,
+
+    @Column(name = "recent_chat_id", nullable = false, columnDefinition = "BINARY(16)")
+    val recentChatId: UUID
 
     //TODO 나중에 그룹채팅 기능 추가되면 방 권한도 추가
 ) {
+    val recentChatTime: Instant
+        get() = UUIDUtils.getInstant(recentChatId)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/domain/RoomUser.kt
@@ -6,7 +6,15 @@ import javax.persistence.*
 /**
  * 채팅 방에서의 사용자 정보를 저장하는 엔티티 입니다.
  */
-@Entity(name = "room_user")
+@Entity
+@Table(
+    name = "room_user", indexes = [
+        Index(
+            name = "room_user_idx_1",
+            columnList = "user_id, room_id, last_viewed_time DESC"
+        )
+    ]
+)
 class RoomUser(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "room_user_id")
@@ -16,13 +24,13 @@ class RoomUser(
     @JoinColumn(name = "room_id", referencedColumnName = "room_id")
     val room: Room,
 
-    @Column(name = "room_name")
+    @Column(name = "room_name", nullable = false)
     val roomName: String,
 
-    @Column(name = "user_id", unique = true)
+    @Column(name = "user_id", nullable = false)
     val userId: Long,
 
-    @Column(name = "last_viewed_time", unique = true)
+    @Column(name = "last_viewed_time", nullable = false)
     val lastViewedTime: LocalDateTime
 
     //TODO 나중에 그룹채팅 기능 추가되면 방 권한도 추가

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
@@ -1,11 +1,20 @@
 package team.themoment.gsmNetworking.domain.room.dto.domain
 
-import java.time.LocalDateTime
+import team.themoment.gsmNetworking.domain.chat.enums.ChatType
+import java.util.UUID
 
 data class RoomUserDto(
     val id: Long,
     val userId: Long,
     val roomId: Long,
     val roomName: String,
-    val lastViewedTime: LocalDateTime
-)
+    val lastViewedChatId: UUID,
+    val maxChatInfo: MaxChatInfo
+) {
+    data class MaxChatInfo(
+        val id: UUID,
+        val content: String,
+        val senderId: Long,
+        val type: ChatType
+    )
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/RoomUserDto.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.room.dto.domain
+
+import java.time.LocalDateTime
+
+data class RoomUserDto(
+    val id: Long,
+    val userId: Long,
+    val roomId: Long,
+    val roomName: String,
+    val lastViewedTime: LocalDateTime
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
@@ -1,4 +1,11 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
+
 interface RoomQueryRepository {
+    fun findRoomUserOrNull(userId: Long, roomId: Long): RoomUser?
+    fun findRoomsRecentUpdated(userId: Long, pageable: Pageable): Page<RoomUserDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
@@ -1,11 +1,41 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import team.themoment.gsmNetworking.domain.room.domain.RoomUser
 import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
+import java.time.Instant
 
+/**
+ * [Room], [RoomUser]에 대한 쿼리 기능을 제공하는 리포지토리입니다.
+ *
+ * [RoomUser]는 [Room]에 의존되는 데이터이며, 주로 함께 사용되기 때문에 [RoomQueryRepository]에서 함께 요청합니다.
+ */
 interface RoomQueryRepository {
+
+    /**
+     * 특정 사용자의 특정 방에 대한 정보를 검색합니다.
+     *
+     * @param userId 채팅 정보를 검색할 사용자의 고유 식별자
+     * @param roomId 채팅 정보를 검색할 방의 고유 식별자
+     * @return 해당 사용자의 해당 방에 대한 정보 (존재하지 않으면 null 반환)
+     */
     fun findRoomUserOrNull(userId: Long, roomId: Long): RoomUser?
-    fun findRoomsRecentUpdated(userId: Long, pageable: Pageable): Page<RoomUserDto>
+
+    /**
+     * 특정 사용자의 특정 시간 이전에 채팅이 발생한 방 목록 일부를 조회합니다.
+     *
+     * @param userId 사용자의 고유 식별자
+     * @param time 필터링에 사용될 시간입니다.
+     * @param size 반환할 결과의 개수입니다.
+     * @return [RoomUserDto] 객체의 리스트입니다.
+     */
+    fun findRoomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto>
+
+    /**
+     * 특정 사용자의 최근에 채팅이 발생한 방 목록 일부를 조회합니다.
+     *
+     * @param userId 사용자의 고유 식별자입니다.
+     * @param size 반환할 결과의 개수입니다.
+     * @return 최근 방을 나타내는 [RoomUserDto] 객체의 리스트입니다.
+     */
+    fun findRecentRooms(userId: Long, size: Int): List<RoomUserDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -1,11 +1,110 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
-import team.themoment.gsmNetworking.domain.room.domain.QRoom.room
-import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat
+import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.*
+import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 
+/**
+ * Room 쿼리 관련 레포지토리 [RoomQueryRepository]의 구현 클래스입니다.
+ */
 class RoomQueryRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : RoomQueryRepository {
-    
+
+    /**
+     * 특정 사용자의 특정 방에 대한 정보를 검색합니다.
+     *
+     * @param userId 채팅 정보를 검색할 사용자의 고유 식별자
+     * @param roomId 채팅 정보를 검색할 방의 고유 식별자
+     * @return 해당 사용자의 해당 방에 대한 정보 (존재하지 않으면 null 반환)
+     */
+    override fun findRoomUserOrNull(
+        userId: Long,
+        roomId: Long
+    ): RoomUser? {
+        return queryFactory
+            .select(roomUser)
+            .from(roomUser)
+            .on(
+                roomUser.userId.eq(userId),
+                roomUser.room.id.eq(roomId)
+            )
+            .orderBy(roomUser.lastViewedTime.desc())
+            .fetchFirst()
+    }
+
+    /**
+     * 사용자의 최근 업데이트된 방 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param userId 방 목록을 조회할 사용자의 고유 식별자
+     * @param pageable 페이지 정보 (페이지 번호, 페이지 크기 등)
+     * @return 방 목록과 페이지에 대한 정보
+     */
+    override fun findRoomsRecentUpdated(userId: Long, pageable: Pageable): Page<RoomUserDto> {
+        val rooms = findRoomsByUserId(userId, pageable)
+        val total = findCountUserRooms(userId)
+
+        return PageImpl(rooms, pageable, total)
+    }
+
+    /**
+     * 특정 사용자의 최근 채팅을 기준으로 방 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param userId 방 목록을 조회할 사용자의 고유 식별자
+     * @param pageable 페이지 정보 (페이지 번호, 페이지 크기 등)
+     * @return 방 목록
+     */
+    private fun findRoomsByUserId(userId: Long, pageable: Pageable): List<RoomUserDto> {
+        val subBaseChat = QBaseChat("subBaseChat")
+        val getResentChatIdSubQuery = JPAExpressions
+            .select(subBaseChat.id)
+            .from(subBaseChat)
+            .where(subBaseChat.room.id.eq(roomUser.room.id))
+            .orderBy(subBaseChat.createAt.desc(), subBaseChat.id.desc())
+            .limit(1)
+
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    RoomUserDto::class.java,
+                    roomUser.userId,
+                    roomUser.room.id,
+                    roomUser.roomName,
+                    roomUser.lastViewedTime
+                )
+            )
+            .from(roomUser)
+            .innerJoin(baseChat)
+            .on(
+                roomUser.userId.eq(userId),
+                baseChat.room.id.eq(getResentChatIdSubQuery),
+                baseChat.room.id.eq(roomUser.room.id)
+            )
+            .orderBy(baseChat.createAt.desc(), baseChat.id.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+    }
+
+    /**
+     * 특정 사용자의 방 개수를 조회합니다.
+     *
+     * @param userId 방 개수를 조회할 사용자의 고유 식별자
+     * @return 해당 사용자의 방 개수
+     */
+    private fun findCountUserRooms(userId: Long): Long {
+        return queryFactory
+            .select(roomUser.count())
+            .from(roomUser)
+            .where(roomUser.userId.eq(userId))
+            .fetchFirst() // fetchFirst or fetchOne - 집계함수를 사용하기 때문에 무조건 1 개의 row를 반환한다는 점에선 fetchOne이 맞는거 같은데, 잘 모르겠음 이 경우 nullable 처리를 어떻게 해야 하나? 잘 모르겠음
+    }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -105,6 +105,6 @@ class RoomQueryRepositoryImpl(
             .select(roomUser.count())
             .from(roomUser)
             .where(roomUser.userId.eq(userId))
-            .fetchFirst() // fetchFirst or fetchOne - 집계함수를 사용하기 때문에 무조건 1 개의 row를 반환한다는 점에선 fetchOne이 맞는거 같은데, 잘 모르겠음 이 경우 nullable 처리를 어떻게 해야 하나? 잘 모르겠음
+            .fetchFirst()
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -115,7 +115,7 @@ class RoomQueryRepositoryImpl(
             .select(roomUser.id.count())
             .from(roomUser)
             .where(roomUser.userId.eq(userId))
-            .fetchFirst()
+            .fetchOne()!!
     }
 
     /**

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -95,6 +95,7 @@ class RoomQueryRepositoryImpl(
                 baseChat.id.eq(roomUser.recentChatId),
             )
             .where(
+                // 이 부분까지 on 절에 있는게 맞다고 생각하는데, on절에는 null이 들어갈 수 없어서 where 절로 옮김
                 recentChatIdLtInstant(time)
             )
             .orderBy(roomUser.userId.asc(), roomUser.recentChatId.desc())

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/config/EnableJpaAuditingConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/config/EnableJpaAuditingConfig.kt
@@ -1,8 +1,0 @@
-package team.themoment.gsmNetworking.global.config
-
-import org.springframework.context.annotation.Configuration
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing
-
-@Configuration
-@EnableJpaAuditing
-class EnableJpaAuditingConfig

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/socket/processor/StompErrorProcessor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/socket/processor/StompErrorProcessor.kt
@@ -13,11 +13,11 @@ class StompErrorProcessor(
     private val senders: List<StompSender>
 ) {
 
-    init {
-        require(senders.isNotEmpty()) {
-            "하나 이상의 ${StompSender::javaClass.name}를 등록해야 합니다"
-        }
-    }
+//    init {
+//        require(senders.isNotEmpty()) {
+//            "하나 이상의 ${StompSender::javaClass.name}를 등록해야 합니다"
+//        }
+//    }
 
     /**
      * 처리 가능한 여러 [StompSender]에게 STOMP 에러 처리를 위임합니다.


### PR DESCRIPTION
## 개요
Chat/Room 도메인 엔티티를 수정하고, Repository 메서드를 구현하였습니다.

## 설명
### Chat/Room 도메인 변경사항
1. 인덱스 설정 추가
2. 테이블 이름을 `@Entity` 대신 `@Table` 에서 정의하도록 변경
3. 일부 잘못된 `@Column` 설정 변경
4. Chat 엔티티 ID가 UUIDv7을 사용함
    - 왜 UUID를 사용하는지는 [WIKI](https://github.com/themoment-team/GSM-Networking-server/wiki/%F0%9F%94%97-DB-%EC%8B%9D%EB%B3%84%EC%9E%90-%EA%B0%92%EC%9C%BC%EB%A1%9C-UUID-v7-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)에 정리해놓았음

### Repository 메서드 구현
chat 서비스에 사용되는 Query 메서드를 구현하였습니다.
앞으로 더 추가될 수도 있지만, 주로 사용할 복잡한 쿼리는 이 PR에 구현되어있습니다.

## 피드백 요청
`RoomQueryRepositoryImpl#findCountUserRooms` 가 무조건 long 타입 숫자 하나만 반환하는데,(2이상, 0은 불가능) 
그럼 `fetchFirst` 대신 `fetchOne`을 사용하는게 좋을까요?
(해당 내용 관련된 주석이 실수로 지워지지 않았는데, 수정하도록 하겠습니다.)

그리고 `fetchOne`을 사용하는 경우 반환 타입이 `Long?` 인데, 어느 단에서 예외처리를 하는게 적절할까요.
사용하는 쿼리 특성 상 `RoomQueryRepositoryImpl#findCountUserRooms` 내부에서 `!!` 을 사용할지, 외부에서 `?:` 을 사용할지 고민입니다.
