### PR TITLE
stomp 채팅 목록 가져오는 api 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
@@ -30,6 +30,14 @@ interface StompSender {
     fun sendMessageToUser(message: StompMessage<*>, userId: Long)
 
     /**
+     * 특정 Session에게 Stomp 메시지를 전송합니다.
+     *
+     * @param message 전송할 메시지
+     * @param sessionId 메시지를 전송할 Client의 sessionId
+     */
+    fun sendMessageToSession(message: StompMessage<*>, sessionId: String)
+
+    /**
      * Stomp 에러 메시지를 전송합니다.
      *
      * @param ex 전송할 에러 메시지

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/controller/ChatMessageController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/controller/ChatMessageController.kt
@@ -8,12 +8,16 @@ import team.themoment.gsmNetworking.common.exception.model.ErrorCode
 import team.themoment.gsmNetworking.common.socket.message.StompMessage
 import team.themoment.gsmNetworking.common.util.StompPathUtil
 import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryChatRequest
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryRecentChatRequest
 import team.themoment.gsmNetworking.domain.chat.dto.ws.request.UserChatRequest
 import team.themoment.gsmNetworking.domain.chat.dto.ws.response.ChatResponse
 import team.themoment.gsmNetworking.domain.chat.exception.ChatStompException
 import team.themoment.gsmNetworking.domain.chat.mapper.ChatMapper
 import team.themoment.gsmNetworking.domain.chat.mapper.RoomMapper
 import team.themoment.gsmNetworking.domain.chat.sender.ChatStompSender
+import team.themoment.gsmNetworking.domain.chat.service.QueryChatService
 import team.themoment.gsmNetworking.domain.chat.service.ReceiveService
 import team.themoment.gsmNetworking.domain.room.domain.RoomUser
 import team.themoment.gsmNetworking.domain.room.dto.ws.RoomUserResponse
@@ -23,6 +27,7 @@ import java.security.Principal
 @RestController
 class ChatMessageController(
     private val receiveService: ReceiveService,
+    private val queryChatService: QueryChatService,
     private val chatStompSender: ChatStompSender
 ) {
 
@@ -48,10 +53,54 @@ class ChatMessageController(
         }
     }
 
+    @MessageMapping("/query/recent-chats")
+    fun queryRecentChat(
+        @Payload queryRecentChatRequest: QueryRecentChatRequest,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        try {
+            val rs = queryChatService.recentChats(queryRecentChatRequest)
+
+            sendChatsToSession(rs, sessionId)
+
+        } catch (ex: IllegalArgumentException) {
+            throw ChatStompException(
+                code = ErrorCode.BAD_REQUEST,
+                message = "존재하지 않는 Room 입니다. id: ${queryRecentChatRequest.roomId}",
+                sessionId = sessionId,
+                path = "${StompPathUtil.PREFIX_TO_USER}/${sessionId}"
+            )
+        }
+    }
+
+    @MessageMapping("/query/chats")
+    fun queryChat(
+        @Payload queryChatRequest: QueryChatRequest,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        try {
+            val rs = queryChatService.chatsByTimeAndDirection(queryChatRequest)
+
+            sendChatsToSession(rs, sessionId)
+
+        } catch (ex: IllegalArgumentException) {
+            throw ChatStompException(
+                code = ErrorCode.BAD_REQUEST,
+                message = "존재하지 않는 Room 입니다. id: ${queryChatRequest.roomId}",
+                sessionId = sessionId,
+                path = "${StompPathUtil.PREFIX_TO_USER}/${sessionId}"
+            )
+        }
+    }
+
     private fun sendChatToRoomUsers(savedChat: BaseChat) {
         val ms: ChatResponse = ChatMapper.chatToChatResponse(savedChat)
         val path = "${StompPathUtil.PREFIX_TO_ROOM}/${savedChat.room.id}"
         chatStompSender.sendMessage(StompMessage(ms), path)
+    }
+
+    private fun sendChatsToSession(chats: List<BaseChatDto>, sessionId: String) {
+        chatStompSender.sendMessageToSession(StompMessage(chats), sessionId)
     }
 
     private fun sendUpdatedRoomInfoToUsers(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/ws/request/QueryChatRequest.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/ws/request/QueryChatRequest.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.chat.dto.ws.request
+
+import team.themoment.gsmNetworking.domain.chat.enums.Direction
+import java.time.Instant
+
+data class QueryChatRequest(
+    val roomId: Long,
+    val direction: Direction,
+    val time: Long,
+    val limit: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/ws/request/QueryRecentChatRequest.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/dto/ws/request/QueryRecentChatRequest.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.chat.dto.ws.request
+
+
+data class QueryRecentChatRequest(
+    val roomId: Long,
+    val limit: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/service/QueryChatService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/service/QueryChatService.kt
@@ -1,0 +1,14 @@
+package team.themoment.gsmNetworking.domain.chat.service
+
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryChatRequest
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryRecentChatRequest
+
+/**
+ * 채팅 목록을 가져옵니다.
+ */
+interface QueryChatService {
+    fun chatsByTimeAndDirection(req : QueryChatRequest) : List<BaseChatDto>
+
+    fun recentChats(req : QueryRecentChatRequest) : List<BaseChatDto>
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/service/impl/QueryChatServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/chat/service/impl/QueryChatServiceImpl.kt
@@ -1,0 +1,37 @@
+package team.themoment.gsmNetworking.domain.chat.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.chat.dto.domain.BaseChatDto
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryChatRequest
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryRecentChatRequest
+import team.themoment.gsmNetworking.domain.chat.repository.ChatRepository
+import team.themoment.gsmNetworking.domain.chat.service.QueryChatService
+import team.themoment.gsmNetworking.domain.room.repository.RoomRepository
+import java.lang.IllegalArgumentException
+import java.time.Instant
+
+@Service
+class QueryChatServiceImpl(
+    private val roomRepository: RoomRepository,
+    private val chatRepository: ChatRepository
+) : QueryChatService {
+
+    @Transactional(readOnly = true)
+    override fun chatsByTimeAndDirection(req: QueryChatRequest): List<BaseChatDto> {
+        validateRoomId(req.roomId)
+        return chatRepository.findChatsByTimeAndDirection(req.roomId, req.direction, Instant.ofEpochMilli(req.time), req.limit)
+    }
+
+    @Transactional(readOnly = true)
+    override fun recentChats(req: QueryRecentChatRequest): List<BaseChatDto> {
+        validateRoomId(req.roomId)
+        return chatRepository.findRecentChats(req.roomId, req.limit)
+    }
+
+    private fun validateRoomId(roomId: Long) {
+        if (!roomRepository.existsById(roomId)) {
+            throw IllegalArgumentException("유효하지 않은 roomId 입니다. roomId가 $roomId 인 Room을 찾을 수 없습니다.")
+        }
+    }
+}


### PR DESCRIPTION
## 개요
stomp 채팅 목록 가져오는 api를 구현하였습니다.

## 설명
#### 수정
- `ChatStompSender`: 요청을 보낸 session에만 응답을 전송하는 `sendMessageToSession`를 구현하였습니다.
   - 테스트 툴의 문제로 인해 valid 문이 대체되었습니다. 자세한 설명은 아래를 확인해주세요.
#### 추가
##### 채팅 목록 가져오기 기능 구현
- `QueryRecentChatRequest`, `QueryChatRequest` : requset에 사용되는 dto입니다.
- `QueryChatService`, `QueryChatServiceImpl` : chat 목록을 가져오는 객체입니다.
- `ChatMessageController`: chat 요청 api를 받고 응답하는 메서드 `queryRecentChat`, `queryChat`을 추가하였습니다.


### Apic 툴 문제
stomp 테스트에 apic 이라는 툴을 사용하는데, 툴에서 Connect와 Subscribe이 한 번에 처리됩니다.
실제로는 한 Connect에 여러 Subscribe이 가능해야 하는데, Apic에선 한 Connect이 한 Subscribe밖에 가질 수 없습니다.
이로 인해서 실제 환경과 동일한 상황에서 요청을 보낼 수 없는 문제가 있습니다.

더 좋은 툴을 찾고 자유롭게 테스트가 가능하면 `sendMessageToSession` valid 로직을 개선할 생각입니다.
