### PR TITLE
LoggingFilter에서 Cookie가 Null인 request 로깅 시 NPE 발생하는 문제 해결

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/filter/LoggingFilter.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/filter/LoggingFilter.kt
@@ -43,9 +43,11 @@ class LoggingFilter : OncePerRequestFilter() {
     private fun requestLogging(request: ContentCachingRequestWrapper, logId: UUID) {
         log.info(
             "Log-ID: $logId, IP: ${request.remoteAddr}, URI: ${request.requestURI}, Http Method: ${request.method}, Params: ${request.queryString}, Content-Type: ${request.contentType}, User-Cookies: ${
-                request.cookies.joinToString(
-                    ", "
-                ) { "${it.name}=${it.value}" }
+                request.cookies?.let {
+                    it.joinToString(
+                        ", "
+                    ) { "${it.name}=${it.value}" }
+                }
             }, User-Agent: ${request.getHeader("User-Agent")}, Body: ${getRequestBody(request.inputStream)}"
         )
     }


### PR DESCRIPTION
## 개요

LoggingFilter에서 Cookie가 Null인 request 로깅 시 NPE 발생하는 문제를 해결하였습니다.

## 설명
nullable한 객체 `request.cookies`를 non-nullable하게 가져와서 NPE가 발생합니다.

`request.cookies?`로 nullable하게 변경하고, 
null이 아닌 경우에만 `joinToString`이 실행되도록 `.let` 을 추가하였습니다.