### PR TITLE
STOMP SockJS 호환 설정 적용

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/config/StompWebSocketConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/config/StompWebSocketConfig.kt
@@ -23,6 +23,7 @@ class StompWebSocketConfig(
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*") // TODO 보안 설정 나중에 추가하기
+            .withSockJS()
         registry.setErrorHandler(StompErrorHandler())
     }
 


### PR DESCRIPTION
## 설명

alb -> ec2 환경에서 STOMP 통신을 사용하기 위해서 SockJs를 사용하도록 설정을 추가하였습니다.

SockJs를 사용하는 것 말고 다른 방법이 있지만, 가장 간편한 방법이라 사용하였습니다.

## 참고
https://mumomu.tistory.com/134