### PR TITLE
STOMP 방 목록 API 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomMessageController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomMessageController.kt
@@ -26,7 +26,7 @@ class RoomMessageController(
 ) {
 
     @MessageMapping("/query/recent-rooms")
-    fun queryRecentChats(
+    fun queryRecentRooms(
         @Payload req: QueryRecentRoomsRequest,
         principal: Principal,
         @Header("simpSessionId") sessionId: String
@@ -34,7 +34,7 @@ class RoomMessageController(
         try {
             val rs = queryRoomService.recentRooms(req.userId, req.limit)
 
-            sendChatsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
+            sendRoomsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
 
         } catch (ex: IllegalArgumentException) {
             throw ChatStompException(
@@ -47,7 +47,7 @@ class RoomMessageController(
     }
 
     @MessageMapping("/query/rooms")
-    fun queryChats(
+    fun queryRooms(
         @Payload req: QueryRoomsRequest,
         principal: Principal,
         @Header("simpSessionId") sessionId: String
@@ -55,7 +55,7 @@ class RoomMessageController(
         try {
             val rs = queryRoomService.roomsByTime(req.userId, Instant.ofEpochMilli(req.time), req.limit)
 
-            sendChatsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
+            sendRoomsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
 
         } catch (ex: IllegalArgumentException) {
             throw ChatStompException(
@@ -67,7 +67,7 @@ class RoomMessageController(
         }
     }
 
-    private fun sendChatsToSession(chats: List<RoomUserResponse>, sessionId: String) {
+    private fun sendRoomsToSession(chats: List<RoomUserResponse>, sessionId: String) {
         chatStompSender.sendMessageToSession(StompMessage(chats), sessionId)
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomMessageController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomMessageController.kt
@@ -1,0 +1,73 @@
+package team.themoment.gsmNetworking.domain.chat.controller
+
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.common.exception.model.ErrorCode
+import team.themoment.gsmNetworking.common.socket.message.StompMessage
+import team.themoment.gsmNetworking.common.util.StompPathUtil
+import team.themoment.gsmNetworking.domain.chat.dto.ws.request.QueryRecentRoomsRequest
+import team.themoment.gsmNetworking.domain.chat.exception.ChatStompException
+import team.themoment.gsmNetworking.domain.chat.mapper.RoomMapper
+import team.themoment.gsmNetworking.domain.chat.sender.ChatStompSender
+import team.themoment.gsmNetworking.domain.room.dto.ws.RoomUserResponse
+import team.themoment.gsmNetworking.domain.room.dto.ws.request.QueryRoomsRequest
+import team.themoment.gsmNetworking.domain.room.service.QueryRoomService
+import java.lang.IllegalArgumentException
+import java.security.Principal
+import java.time.Instant
+
+@RestController
+class RoomMessageController(
+    //TODO 굳이 도메인 별로 StompSender 필요 없을 듯? Excepotion은 따로 분기처리하고
+    private val chatStompSender: ChatStompSender,
+    private val queryRoomService: QueryRoomService
+) {
+
+    @MessageMapping("/query/recent-rooms")
+    fun queryRecentChats(
+        @Payload req: QueryRecentRoomsRequest,
+        principal: Principal,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        try {
+            val rs = queryRoomService.recentRooms(req.userId, req.limit)
+
+            sendChatsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
+
+        } catch (ex: IllegalArgumentException) {
+            throw ChatStompException(
+                code = ErrorCode.BAD_REQUEST,
+                message = "존재하지 않는 User 입니다. id: ${req.userId}",
+                sessionId = sessionId,
+                path = "${StompPathUtil.PREFIX_TO_USER}/${sessionId}"
+            )
+        }
+    }
+
+    @MessageMapping("/query/rooms")
+    fun queryChats(
+        @Payload req: QueryRoomsRequest,
+        principal: Principal,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        try {
+            val rs = queryRoomService.roomsByTime(req.userId, Instant.ofEpochMilli(req.time), req.limit)
+
+            sendChatsToSession(RoomMapper.roomUserDtosToListRoomUserResponses(rs), sessionId)
+
+        } catch (ex: IllegalArgumentException) {
+            throw ChatStompException(
+                code = ErrorCode.BAD_REQUEST,
+                message = "존재하지 않는 User 입니다. id: ${req.userId}",
+                sessionId = sessionId,
+                path = "${StompPathUtil.PREFIX_TO_USER}/${sessionId}"
+            )
+        }
+    }
+
+    private fun sendChatsToSession(chats: List<RoomUserResponse>, sessionId: String) {
+        chatStompSender.sendMessageToSession(StompMessage(chats), sessionId)
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/RoomUserResponse.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/RoomUserResponse.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.domain.room.dto.ws
 
+import team.themoment.gsmNetworking.common.util.UUIDUtils
 import team.themoment.gsmNetworking.domain.chat.enums.ChatType
 import java.util.*
 
@@ -15,6 +16,7 @@ data class RoomUserResponse(
         val id: UUID,
         val content: String,
         val senderId: Long,
-        val type: ChatType
+        val type: ChatType,
+        val createAt: Long = UUIDUtils.getEpochMilli(id)
     )
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/request/QueryRecentRoomsRequest.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/request/QueryRecentRoomsRequest.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.chat.dto.ws.request
+
+
+data class QueryRecentRoomsRequest(
+    val userId: Long,
+    val limit: Int
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/request/QueryRoomsRequest.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/ws/request/QueryRoomsRequest.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.room.dto.ws.request
+
+data class QueryRoomsRequest(
+    val userId: Long,
+    val time: Long,
+    val limit: Int
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/mapper/RoomMapper.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/mapper/RoomMapper.kt
@@ -2,6 +2,7 @@ package team.themoment.gsmNetworking.domain.chat.mapper
 
 import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
 import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 import team.themoment.gsmNetworking.domain.room.dto.ws.RoomUserResponse
 
 class RoomMapper {
@@ -23,5 +24,24 @@ class RoomMapper {
                 )
             )
         }
+
+        fun roomUserDtoToRoomUserResponse(dto: RoomUserDto): RoomUserResponse {
+            return RoomUserResponse(
+                roomUserId = dto.id,
+                userId = dto.userId,
+                roomId = dto.roomId,
+                roomName = dto.roomName,
+                lastViewedChatId = dto.lastViewedChatId,
+                recentChatInfo = RoomUserResponse.RecentChatInfo(
+                    id = dto.maxChatInfo.id,
+                    content = dto.maxChatInfo.content,
+                    senderId = dto.maxChatInfo.senderId,
+                    type = dto.maxChatInfo.type
+                )
+            )
+        }
+
+        fun roomUserDtosToListRoomUserResponses(dtos: List<RoomUserDto>): List<RoomUserResponse> =
+            dtos.map { roomUserDtoToRoomUserResponse(it) }
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomService.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.room.service
+
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
+import java.time.Instant
+
+
+interface QueryRoomService {
+    fun recentRooms(userId: Long, size: Int) : List<RoomUserDto>
+
+    fun roomsByTime(userId: Long, time: Instant, size: Int) : List<RoomUserDto>
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomServiceImpl.kt
@@ -1,0 +1,30 @@
+package team.themoment.gsmNetworking.domain.room.service
+
+import org.springframework.stereotype.Service
+import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
+import team.themoment.gsmNetworking.domain.room.repository.RoomRepository
+import team.themoment.gsmNetworking.domain.user.repository.UserRepository
+import java.lang.IllegalArgumentException
+import java.time.Instant
+
+@Service
+class QueryRoomServiceImpl(
+    private val roomRepository: RoomRepository,
+    private val userRepository: UserRepository
+) : QueryRoomService {
+    override fun recentRooms(userId: Long, size: Int): List<RoomUserDto> {
+        validUser(userId)
+        return roomRepository.findRecentRooms(userId, size)
+    }
+
+    override fun roomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto> {
+        validUser(userId)
+        return roomRepository.findRoomsByTime(userId, time, size)
+    }
+
+    private fun validUser(userId: Long) {
+        if(!userRepository.existsById(userId)) {
+            throw IllegalArgumentException("유효하지 않은 userId 입니다. userId가 $userId 인 User를 찾을 수 없습니다.")
+        }
+    }
+}


### PR DESCRIPTION
## 개요
방 목록을 요청하는 STOMP API를 구현하였습니다.

## 설명

#### `ChatMessageController` 및 RequestDto 구현
- `ChatMessageController#queryRecentRooms`: 최근 방 목록을 가져옵니다.
  - `QueryRecentRoomsRequest` 해당 API의 RequestDto
- `ChatMessageController#queryRooms`: 요청한 시간대 이전의 방 목록을 가져옵니다.
  - `QueryRoomsRequest` 해당 API의 RequestDto

#### `QueryRoomService` 및 구현체 구현
최근 방 목록 또는 특정 시간 이전 방 목록을 불러오는 서비스 객체입니다.

#### `RoomMapper` 메서드 추가
`roomUserDtoToRoomUserResponse`, `roomUserDtoToRoomUserResponses` 메서드를 추가하였습니다.

####  `RoomUserResponse` `createAt` 필드 추가 
`RoomUserResponse`에 `createAt` 필드를 추가하였습니다.