### PR TITLE
방 관련 HTTP API 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomController.kt
@@ -1,0 +1,70 @@
+package team.themoment.gsmNetworking.domain.room.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import team.themoment.gsmNetworking.common.exception.ExpectedException
+import team.themoment.gsmNetworking.common.socket.message.StompMessage
+import team.themoment.gsmNetworking.common.util.StompPathUtil
+import team.themoment.gsmNetworking.domain.chat.domain.BaseChat
+import team.themoment.gsmNetworking.domain.chat.dto.ws.response.ChatResponse
+import team.themoment.gsmNetworking.domain.chat.mapper.ChatMapper
+import team.themoment.gsmNetworking.domain.chat.mapper.RoomMapper
+import team.themoment.gsmNetworking.domain.chat.sender.ChatStompSender
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.api.RoomRegistrationDto
+import team.themoment.gsmNetworking.domain.room.dto.domain.FetchRoomDto
+import team.themoment.gsmNetworking.domain.room.dto.ws.RoomUserResponse
+import team.themoment.gsmNetworking.domain.room.service.CreateRoomService
+import team.themoment.gsmNetworking.domain.room.service.QueryRoomService
+
+@RestController
+@RequestMapping("api/v1/room")
+class RoomController(
+    private val queryRoomService: QueryRoomService,
+    private val createRoomService: CreateRoomService,
+    private val chatStompSender: ChatStompSender
+) {
+    @PostMapping("")
+    fun createRoom(@RequestBody req: RoomRegistrationDto): ResponseEntity<Room> {
+        try {
+            val rs = createRoomService.execute(req.user1Id, req.user2Id)
+
+            sendChatToRoomUsers(rs.savedChat)
+            sendUpdatedRoomInfoToUsers(rs.savedChat, rs.updatedRoomUsers)
+        } catch (ex: IllegalArgumentException) {
+            throw ExpectedException(ex.message.orEmpty(), HttpStatus.BAD_REQUEST)
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping("/by-user-ids")
+    fun findRoomById(
+        @RequestParam(name = "user1Id", required = true) user1Id: Long,
+        @RequestParam(name = "user2Id", required = true) user2Id: Long
+    ): ResponseEntity<FetchRoomDto> {
+        val rs: FetchRoomDto? = queryRoomService.findRoomByUserIds(user1Id, user2Id)
+        return rs?.let { ResponseEntity.ok(it) } ?: ResponseEntity.noContent().build()
+    }
+
+    private fun sendChatToRoomUsers(savedChat: BaseChat) {
+        val ms: ChatResponse = ChatMapper.chatToChatResponse(savedChat)
+        val path = "${StompPathUtil.PREFIX_TO_ROOM}/${savedChat.room.id}"
+        chatStompSender.sendMessage(StompMessage(ms), path)
+    }
+
+    private fun sendUpdatedRoomInfoToUsers(
+        savedChat: BaseChat,
+        newRoomUsers: List<RoomUser>
+    ) {
+        newRoomUsers.forEach {
+            val message: RoomUserResponse = RoomMapper.chatAndRoomUserToRoomUserResponse(savedChat, it)
+            chatStompSender.sendMessageToUser(
+                StompMessage(message),
+                it.userId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/controller/RoomController.kt
@@ -31,6 +31,7 @@ class RoomController(
         try {
             val rs = createRoomService.execute(req.user1Id, req.user2Id)
 
+            // TODO 굳이 채팅 방까지 문자 보낼 필요가 있을까?
             sendChatToRoomUsers(rs.savedChat)
             sendUpdatedRoomInfoToUsers(rs.savedChat, rs.updatedRoomUsers)
         } catch (ex: IllegalArgumentException) {
@@ -41,7 +42,7 @@ class RoomController(
     }
 
     @GetMapping("/by-user-ids")
-    fun findRoomById(
+    fun findRoomByUserIds(
         @RequestParam(name = "user1Id", required = true) user1Id: Long,
         @RequestParam(name = "user2Id", required = true) user2Id: Long
     ): ResponseEntity<FetchRoomDto> {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/api/RoomRegistrationDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/api/RoomRegistrationDto.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.room.dto.api
+
+data class RoomRegistrationDto(
+    val user1Id: Long,
+    val user2Id: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/FetchRoomDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/dto/domain/FetchRoomDto.kt
@@ -1,0 +1,17 @@
+package team.themoment.gsmNetworking.domain.room.dto.domain
+
+import java.util.*
+
+data class FetchRoomDto(
+    val roomId: Long,
+    val roomUsers: List<RoomUserDto>,
+) {
+    data class RoomUserDto(
+        val id: Long,
+        val userId: Long,
+        val roomName: String,
+        val lastViewedChatId: UUID,
+        val recentChatId: UUID
+    )
+}
+

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepository.kt
@@ -1,6 +1,8 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
+import team.themoment.gsmNetworking.domain.room.domain.Room
 import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.FetchRoomDto
 import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 import java.time.Instant
 
@@ -29,6 +31,15 @@ interface RoomQueryRepository {
      * @return [RoomUserDto] 객체의 리스트입니다.
      */
     fun findRoomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto>
+
+    /**
+     * 두 사용자 사이의 채팅방을 가져옵니다.
+     *
+     * @param user1Id 사용자 1의 식별자
+     * @param user2Id 사용자 2의 식별자
+     * @return [FetchRoomDto] 반환, 조건을 만족하는 값이 없다면 Null 반환
+     */
+    fun findRoomByUserIds(user1Id: Long, user2Id: Long) : FetchRoomDto?
 
     /**
      * 특정 사용자의 최근에 채팅이 발생한 방 목록 일부를 조회합니다.

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/repository/RoomQueryRepositoryImpl.kt
@@ -1,12 +1,19 @@
 package team.themoment.gsmNetworking.domain.room.repository
 
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
 import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.JPAExpressions
+import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import team.themoment.gsmNetworking.common.util.UUIDUtils
 import team.themoment.gsmNetworking.domain.chat.domain.QBaseChat.*
+import team.themoment.gsmNetworking.domain.room.domain.QRoom.room
+import team.themoment.gsmNetworking.domain.room.domain.QRoomUser
 import team.themoment.gsmNetworking.domain.room.domain.QRoomUser.roomUser
 import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.dto.domain.FetchRoomDto
 import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 import java.time.Instant
 
@@ -49,6 +56,71 @@ class RoomQueryRepositoryImpl(
      */
     override fun findRoomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto> =
         findRooms(userId, time, size)
+
+    /**
+     * 두 사용자 사이의 채팅방을 가져옵니다.
+     *
+     * @param user1Id 사용자 1의 식별자
+     * @param user2Id 사용자 2의 식별자
+     * @return [FetchRoomDto] 반환, 조건을 만족하는 값이 없다면 Null 반환
+     */
+    override fun findRoomByUserIds(
+        user1Id: Long,
+        user2Id: Long
+    ): FetchRoomDto? {
+        // user1가 참여 중인 방 id 목록을 구하는 서브쿼리
+        val sub1 = JPAExpressions
+            .select(roomUser.room.id)
+            .from(roomUser)
+            .where(roomUser.userId.eq(user1Id))
+
+        // user2가 참여 중인 방 id 목록을 구하는 서브쿼리
+        val sub2 = JPAExpressions
+            .select(roomUser.room.id)
+            .from(roomUser)
+            .where(roomUser.userId.eq(user2Id))
+
+        // 현재 구현 상, 1:1 채팅만 지원하므로 두 사용자가 여러 방을 가질 수 없다.
+        // 그래서 해당 서브쿼리의 결과는 1 row 임이 보장되며, 메인 쿼리에서 eq 조건으로 쓰인다.
+        val unionSub = JPAExpressions
+            .select(room.id)
+            .from(room)
+            .where(
+                room.id.`in`(sub1),
+                room.id.`in`(sub2),
+            )
+
+        val rs = queryFactory
+            .selectFrom(room)
+            .where(room.id.eq(unionSub))
+            .join(room.roomUsers, roomUser)
+            .transform(
+                groupBy(room).list(
+                    Projections.constructor(
+                        FetchRoomDto::class.java,
+                        room.id,
+                        list(
+                            Projections.constructor(
+                                FetchRoomDto.RoomUserDto::class.java,
+                                roomUser.id,
+                                roomUser.userId,
+                                roomUser.roomName,
+                                roomUser.lastViewedChatId,
+                                roomUser.recentChatId
+                            )
+                        )
+                    )
+                )
+            )
+
+        return if (rs.isEmpty()) {
+            null
+        } else if (rs.size == 1) {
+            rs[0]
+        } else {
+            throw IllegalStateException("현재 구현 상, 1:1 채팅만 지원하므로 두 사용자가 여러 방을 가질 수 없습니다.")
+        }
+    }
 
     /**
      * 특정 사용자의 최근에 채팅이 발생한 방 목록 일부를 조회합니다.

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/CreateRoomService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/CreateRoomService.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.room.service
+
+import team.themoment.gsmNetworking.domain.chat.dto.ws.response.UserChatServiceRs
+
+interface CreateRoomService {
+    fun execute(user1Id: Long, user2Id: Long) : UserChatServiceRs
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/CreateRoomServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/CreateRoomServiceImpl.kt
@@ -1,0 +1,81 @@
+package team.themoment.gsmNetworking.domain.room.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.chat.domain.SystemChat
+import team.themoment.gsmNetworking.domain.chat.dto.ws.response.UserChatServiceRs
+import team.themoment.gsmNetworking.domain.chat.repository.ChatRepository
+import team.themoment.gsmNetworking.domain.room.domain.Room
+import team.themoment.gsmNetworking.domain.room.domain.RoomUser
+import team.themoment.gsmNetworking.domain.room.repository.RoomRepository
+import team.themoment.gsmNetworking.domain.room.repository.RoomUserRepository
+import team.themoment.gsmNetworking.domain.user.domain.User
+import team.themoment.gsmNetworking.domain.user.repository.UserRepository
+import java.util.UUID
+
+@Service
+class CreateRoomServiceImpl(
+    private val userRepository: UserRepository,
+    private val roomRepository: RoomRepository,
+    private val roomUserRepository: RoomUserRepository,
+    private val chatRepository: ChatRepository
+) : CreateRoomService {
+
+    @Transactional
+    override fun execute(user1Id: Long, user2Id: Long): UserChatServiceRs {
+        val user1 = getUserById(user1Id)
+        val user2 = getUserById(user2Id)
+
+        validateRoomNotExist(user1Id, user2Id)
+
+        val initRoom = createNewRoom()
+        val initChat = createSystemChat(initRoom)
+
+        val roomUser1 = createRoomUser(user1, user2.name, initChat.id, initChat.id, initRoom)
+        val roomUser2 = createRoomUser(user2, user1.name, initChat.id, initChat.id, initRoom)
+
+        val savedRoomUsers = saveRoomUsers(listOf(roomUser1, roomUser2))
+
+        //TODO UserChatServiceRs 이름 바꾸기 -> ChatServiceRs ?
+        return UserChatServiceRs(initChat, savedRoomUsers)
+    }
+
+    private fun getUserById(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException("userId가 $userId 인 사용자를 찾을 수 없습니다") }
+    }
+
+    private fun validateRoomNotExist(user1Id: Long, user2Id: Long) {
+        if (roomRepository.findRoomByUserIds(user1Id, user2Id) != null) {
+            throw IllegalArgumentException("userId가 $user1Id, $user2Id 인 사용자는 이미 채탕방이 존재합니다")
+        }
+    }
+
+    private fun createNewRoom(): Room {
+        return roomRepository.save(Room(roomUsers = emptyList()))
+    }
+
+    private fun createSystemChat(room: Room): SystemChat {
+        return chatRepository.save(SystemChat(room = room, content = "채팅을 시작합니다."))
+    }
+
+    private fun createRoomUser(
+        user: User,
+        roomName: String,
+        lastViewedChatId: UUID,
+        recentChatId: UUID,
+        room: Room
+    ): RoomUser {
+        return RoomUser(
+            room = room,
+            roomName = roomName,
+            userId = user.userId,
+            lastViewedChatId = lastViewedChatId,
+            recentChatId = recentChatId
+        )
+    }
+
+    private fun saveRoomUsers(roomUsers: List<RoomUser>): List<RoomUser> {
+        return roomUserRepository.saveAll(roomUsers).toList()
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomService.kt
@@ -1,11 +1,14 @@
 package team.themoment.gsmNetworking.domain.room.service
 
+import team.themoment.gsmNetworking.domain.room.dto.domain.FetchRoomDto
 import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 import java.time.Instant
 
 
 interface QueryRoomService {
-    fun recentRooms(userId: Long, size: Int) : List<RoomUserDto>
+    fun recentRooms(userId: Long, size: Int): List<RoomUserDto>
 
-    fun roomsByTime(userId: Long, time: Instant, size: Int) : List<RoomUserDto>
+    fun findRoomByUserIds(user1Id: Long, user2Id: Long): FetchRoomDto?
+
+    fun roomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/room/service/QueryRoomServiceImpl.kt
@@ -1,6 +1,8 @@
 package team.themoment.gsmNetworking.domain.room.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.room.dto.domain.FetchRoomDto
 import team.themoment.gsmNetworking.domain.room.dto.domain.RoomUserDto
 import team.themoment.gsmNetworking.domain.room.repository.RoomRepository
 import team.themoment.gsmNetworking.domain.user.repository.UserRepository
@@ -12,18 +14,26 @@ class QueryRoomServiceImpl(
     private val roomRepository: RoomRepository,
     private val userRepository: UserRepository
 ) : QueryRoomService {
+
+    @Transactional(readOnly=true)
     override fun recentRooms(userId: Long, size: Int): List<RoomUserDto> {
         validUser(userId)
         return roomRepository.findRecentRooms(userId, size)
     }
 
+    @Transactional(readOnly=true)
+    override fun findRoomByUserIds(user1Id: Long, user2Id: Long): FetchRoomDto? {
+        return roomRepository.findRoomByUserIds(user1Id, user2Id)
+    }
+
+    @Transactional(readOnly=true)
     override fun roomsByTime(userId: Long, time: Instant, size: Int): List<RoomUserDto> {
         validUser(userId)
         return roomRepository.findRoomsByTime(userId, time, size)
     }
 
     private fun validUser(userId: Long) {
-        if(!userRepository.existsById(userId)) {
+        if (!userRepository.existsById(userId)) {
             throw IllegalArgumentException("유효하지 않은 userId 입니다. userId가 $userId 인 User를 찾을 수 없습니다.")
         }
     }


### PR DESCRIPTION
## 개요
방 관련 HTTP API를 구현하였습니다.

## 설명

#### 1. 두 사용자 간의 채팅을 가져오는 기능 추가
`CreateRoomService#execute`

#### 2. 새로운 채팅을 추가하는 기능 추가
`QueryRoomService#findRoomByUserIds` 

#### 3. `QueryRoomServiceImpl` 쿼리 성 메서드에 `readOnly` 옵션 추가

#### 4. `RoomController` 구현
- `#createRoom` :  방을 생성하고, 방 생성 시 생성된 SYSTEM CHAT 정보를 사용자에게 전달합니다.
- `#findRoomById` :  두 사용자의 ID를 받아서 두 사용자 사이의 채팅 방을 반환합니다.