### PR TITLE
멘토 삭제 외래 키 제약조건 에러 해결

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Career.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Career.kt
@@ -14,9 +14,8 @@ class Career(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val careerId: Long = 0,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, )
     @JoinColumn(name = "mentor_id")
-    @Cascade(value = [CascadeType.DELETE]) // 멘토가 삭제될 시에 경력도 삭제 된다.
     val mentor: Mentor,
 
     @Column(nullable = false)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Career.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Career.kt
@@ -14,7 +14,7 @@ class Career(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val careerId: Long = 0,
 
-    @ManyToOne(fetch = FetchType.LAZY, )
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mentor_id")
     val mentor: Mentor,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CareerRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/CareerRepository.kt
@@ -2,5 +2,10 @@ package team.themoment.gsmNetworking.domain.mentor.repository
 
 import team.themoment.gsmNetworking.domain.mentor.domain.Career
 import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.mentor.domain.Mentor
 
-interface CareerRepository : CrudRepository<Career, Long>
+interface CareerRepository : CrudRepository<Career, Long> {
+
+    fun deleteByMentor(mentor: Mentor)
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorRepository.kt
@@ -8,5 +8,8 @@ import team.themoment.gsmNetworking.domain.user.domain.User
  * Mentor Entity를 위한 Repository 인터페이스 입니다.
  */
 interface MentorRepository : CrudRepository<Mentor, Long>, MentorCustomRepository {
+
     fun deleteByUser(user: User)
+    fun findByUser(user: User): Mentor?
+
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
@@ -4,6 +4,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.common.exception.ExpectedException
+import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
+import team.themoment.gsmNetworking.domain.auth.domain.Authority
+import team.themoment.gsmNetworking.domain.mentor.repository.CareerRepository
 import team.themoment.gsmNetworking.domain.mentor.repository.MentorRepository
 import team.themoment.gsmNetworking.domain.user.repository.UserRepository
 
@@ -11,13 +14,21 @@ import team.themoment.gsmNetworking.domain.user.repository.UserRepository
 @Transactional(rollbackFor = [Exception::class])
 class DeleteMyMentorInfoService(
     private val userRepository: UserRepository,
-    private val mentorRepository: MentorRepository
+    private val mentorRepository: MentorRepository,
+    private val careerRepository: CareerRepository,
+    private val authenticatedUserManager: AuthenticatedUserManager
 ) {
 
     fun execute(authenticationId: Long) {
         val user = userRepository.findByAuthenticationId(authenticationId)
             ?: throw ExpectedException("존재하지 않는 user입니다.", HttpStatus.NOT_FOUND)
+        val mentor = mentorRepository.findByUser(user)
+            ?: throw ExpectedException("존재하지 않는 mentor입니다.", HttpStatus.NOT_FOUND)
+
+        careerRepository.deleteByMentor(mentor)
         mentorRepository.deleteByUser(user)
+        userRepository.deleteById(user.userId)
+        authenticatedUserManager.updateAuthority(Authority.TEMP_USER)
     }
 
 }


### PR DESCRIPTION
## 개요

멘토 삭제시 외래 키 제약조건에 의해 발생하는 에러를 해결하였습니다.

## 설명

mentor삭제시 동작하지 않는 career의 mentor에 대한 cascade 코드를 삭제하였습니다.
추후 코드 변경이 필요할 수 있습니다.