### PR TITLE
모든 맨토 조회 시 id가 non-unique 한 문제 해결 & 정렬된 상태로 반환하도록 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
 	kotlin("plugin.jpa") version "1.6.21"
-	kotlin("kapt") version "1.4.10"
+	kotlin("kapt") version "1.9.20"
 }
 
 allOpen {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RestController
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorRegistrationDto
 import team.themoment.gsmNetworking.domain.mentor.service.MentorRegistrationService
-import team.themoment.gsmNetworking.domain.mentor.service.QueryAllMentorsListService
+import team.themoment.gsmNetworking.domain.mentor.service.impl.QueryAllMentorsServiceImpl
 
 @RestController
 @RequestMapping("api/v1/mentor")
 class MentorController(
     private val mentorRegistrationService: MentorRegistrationService,
-    private val queryAllMentorListService: QueryAllMentorsListService
+    private val queryAllMentorListService: QueryAllMentorsServiceImpl
 ) {
 
     @PostMapping

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/MentorController.kt
@@ -19,7 +19,7 @@ import team.themoment.gsmNetworking.domain.mentor.service.QueryAllMentorsService
 @RequestMapping("api/v1/mentor")
 class MentorController(
     private val mentorRegistrationService: MentorRegistrationService,
-    private val queryAllMentorListService: QueryAllMentorsService
+    private val queryAllMentorListService: QueryAllMentorsService,
     private val deleteMyMentorInfoService: DeleteMyMentorInfoService,
     private val authenticatedUserManager: AuthenticatedUserManager
 ) {

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsService.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.mentor.service
+
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+
+
+interface QueryAllMentorsService {
+    fun execute() : List<MentorInfoDto>
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
@@ -28,7 +28,7 @@ class QueryAllMentorsServiceImpl(
             (mentorRepository.findAllMentorInfoDto() + queryTempMentorListService.execute()
                 .map(TempMentorInfoDto::toMentorInfoDto))
                 .distinctBy { Pair(it.generation, it.name) }
-                .sortedWith(compareBy({ it.registered }, { it.position }, { it.generation }, { it.name }))
+                .sortedWith(compareBy({ !it.registered }, { it.position }, { it.generation }, { it.name }))
         generateNewMentorIds(allMentors)
 
         return allMentors

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
@@ -24,22 +24,17 @@ class QueryAllMentorsServiceImpl(
      * @return 모든 멘토 정보가 담긴 dto 리스트
      */
     override fun execute(): List<MentorInfoDto> {
-        val allMentors = (
-                mentorRepository.findAllMentorInfoDto() +
-                        queryTempMentorListService.execute().map(TempMentorInfoDto::toMentorInfoDto)
-                ).distinctBy { Pair(it.generation, it.name) }
-
-        increaseMentorIdCount(allMentors)
+        val allMentors =
+            (mentorRepository.findAllMentorInfoDto() + queryTempMentorListService.execute()
+                .map(TempMentorInfoDto::toMentorInfoDto))
+                .distinctBy { Pair(it.generation, it.name) }
+                .sortedWith(compareBy({ it.registered }, { it.position }, { it.generation }, { it.name }))
+        generateNewMentorIds(allMentors)
 
         return allMentors
     }
 
-    private fun increaseMentorIdCount(allMentors: List<MentorInfoDto>): List<MentorInfoDto> {
-        val newId = 1L
-        allMentors.forEach { mentorInfo ->
-            mentorInfo.id = newId.inc()
-        }
-        return allMentors
-    }
+    private fun generateNewMentorIds(allMentors: List<MentorInfoDto>): List<MentorInfoDto> =
+        allMentors.mapIndexed { newMentorId, mentorInfo -> mentorInfo.copy(id = newMentorId + 1L) }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
@@ -1,27 +1,29 @@
-package team.themoment.gsmNetworking.domain.mentor.service
+package team.themoment.gsmNetworking.domain.mentor.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
 import team.themoment.gsmNetworking.domain.mentor.dto.TempMentorInfoDto
 import team.themoment.gsmNetworking.domain.mentor.repository.MentorCustomRepository
+import team.themoment.gsmNetworking.domain.mentor.service.QueryAllMentorsService
+import team.themoment.gsmNetworking.domain.mentor.service.QueryTempMentorListService
 
 /**
  * 멘토의 정보 리스트로 볼 수 있는 로직이 담긴 클래스 입니다.
  */
 @Service
 @Transactional(readOnly = true)
-class QueryAllMentorsListService(
+class QueryAllMentorsServiceImpl(
     private val mentorRepository: MentorCustomRepository,
     private val queryTempMentorListService: QueryTempMentorListService,
-) {
+) : QueryAllMentorsService {
 
     /**
      * 모든 멘토 리스트를 가져와서 리턴해주는 메서드 입니다.
      *
      * @return 모든 멘토 정보가 담긴 dto 리스트
      */
-    fun execute(): List<MentorInfoDto> {
+    override fun execute(): List<MentorInfoDto> {
         val allMentors = (
                 mentorRepository.findAllMentorInfoDto() +
                         queryTempMentorListService.execute().map(TempMentorInfoDto::toMentorInfoDto)

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -1,0 +1,179 @@
+package team.themoment.gsmNetworking.domain.mentor.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.boot.test.context.SpringBootTest
+import team.themoment.gsmNetworking.domain.mentor.dto.CompanyInfoDto
+import team.themoment.gsmNetworking.domain.mentor.dto.MentorInfoDto
+import team.themoment.gsmNetworking.domain.mentor.dto.TempMentorInfoDto
+import team.themoment.gsmNetworking.domain.mentor.repository.MentorCustomRepository
+import team.themoment.gsmNetworking.domain.mentor.service.impl.QueryAllMentorsServiceImpl
+
+@SpringBootTest(classes = [QueryAllMentorsService::class])
+class QueryAllMentorsServiceTest : BehaviorSpec({
+
+    val mentorRepository: MentorCustomRepository = mockk()
+    val queryTempMentorListService: QueryTempMentorListService = mockk()
+
+    val queryAllMentorsService: QueryAllMentorsService =
+        QueryAllMentorsServiceImpl(mentorRepository, queryTempMentorListService)
+
+    //TODO 더미데이터가 코드를 너무 많이 차지하는데...
+    val dummyMentorInfoDtos = listOf(
+        MentorInfoDto(
+            id = 1L,
+            name = "홍길동",
+            email = "hong@gmail.com",
+            generation = 3,
+            position = "디자이너",
+            company = CompanyInfoDto(
+                name = "ABC 회사",
+                url = "https://www.abc-company.com"
+            ),
+            sns = "https://www.instagram.com/a",
+            profileUrl = "https://www.instagram.com/img/a",
+            registered = true
+        ),
+        MentorInfoDto(
+            id = 2L,
+            name = "김철수",
+            email = "kim@gmail.com",
+            generation = 4,
+            position = "개발자",
+            company = CompanyInfoDto(
+                name = "DEF 회사",
+                url = "https://www.def-company.com"
+            ),
+            sns = "https://www.instagram.com/b",
+            profileUrl = "https://www.instagram.com/img/b",
+            registered = true
+        ),
+        MentorInfoDto(
+            id = 3L,
+            name = "이영희",
+            email = "lee@gmail.com",
+            generation = 5,
+            position = "디자이너",
+            company = CompanyInfoDto(
+                name = "GHI 회사",
+                url = "https://www.ghi-company.com"
+            ),
+            sns = "https://www.instagram.com/c",
+            profileUrl = "https://www.instagram.com/img/c",
+            registered = false
+        ),
+        MentorInfoDto(
+            id = 4L,
+            name = "박철호",
+            email = "park@gmail.com",
+            generation = 2,
+            position = "마케터",
+            company = CompanyInfoDto(
+                name = "JKL 회사",
+                url = "https://www.jkl-company.com"
+            ),
+            sns = "https://www.instagram.com/d",
+            profileUrl = "https://www.instagram.com/img/d",
+            registered = true
+        )
+    )
+
+    val dummyTempMentorInfoDtos = listOf(
+        TempMentorInfoDto(
+            id = 10L,
+            firebaseId = "firebase_1",
+            name = "임꺽정",
+            email = "lim@gmail.com",
+            generation = 2,
+            position = "개발자",
+            company = CompanyInfoDto(
+                name = "GHI 회사",
+                url = "https://www.ghi-company.com"
+            ),
+            snsUrl = "https://www.instagram.com/c"
+        ),
+        TempMentorInfoDto(
+            id = 11L,
+            firebaseId = "firebase_2",
+            name = "유관순",
+            email = "you@gmail.com",
+            generation = 5,
+            position = "기획자",
+            company = CompanyInfoDto(
+                name = "JKL 회사",
+                url = "https://www.jkl-company.com"
+            ),
+            snsUrl = "https://www.instagram.com/d"
+        ),
+        TempMentorInfoDto(
+            id = 12L,
+            firebaseId = "firebase_3",
+            name = "정도전",
+            email = "jeong@gmail.com",
+            generation = 4,
+            position = "개발자",
+            company = CompanyInfoDto(
+                name = "MNO 회사",
+                url = "https://www.mno-company.com"
+            ),
+            snsUrl = "https://www.instagram.com/e"
+        ),
+        TempMentorInfoDto(
+            id = 13L,
+            firebaseId = "firebase_4",
+            name = "김유신",
+            email = "kim@gmail.com",
+            generation = 3,
+            position = "개발자",
+            company = CompanyInfoDto(
+                name = "PQR 회사",
+                url = "https://www.pqr-company.com"
+            ),
+            snsUrl = "https://www.instagram.com/f"
+        )
+    )
+
+    given("블루 체크 사용자는 상위에 노출, 직군끼리 묶인 형태의 리스트 반환") {
+        every { mentorRepository.findAllMentorInfoDto() } returns dummyMentorInfoDtos
+        every { queryTempMentorListService.execute() } returns dummyTempMentorInfoDtos
+
+        `when`("임시 사용자와 블루체크 된 사용자 조회 시") {
+            val allMentors = queryAllMentorsService.execute()
+
+            then("블루체크 된 사용자들이 반환 순서의 앞쪽에 위치한다") {
+                val blueCheckedUsers = allMentors.filter { it.registered }
+                val tempUsers = allMentors.filterNot { it.registered }
+
+                val firstBlueCheckedUser = blueCheckedUsers.firstOrNull()
+                val firstTempUser = tempUsers.firstOrNull()
+
+                // 테스트를 위해서 두 종류 각각 하나 이상 더미가 존재해야 함
+                firstBlueCheckedUser shouldNotBe null
+                firstTempUser shouldNotBe null
+
+                val blueCheckedUserIds = blueCheckedUsers.map { it.id }
+                val tempUserIds = tempUsers.map { it.id }
+
+                // 더미와 리턴 결과의 id가 일치하는지 확인
+                dummyMentorInfoDtos.forEach { it.id shouldBeIn blueCheckedUserIds }
+                dummyTempMentorInfoDtos.forEach { it.id shouldBeIn tempUserIds }
+            }
+
+            then("임시 사용자와 블루체크 된 사용자 각각 직군을 기준으로 정렬된 상태를 가진다") {
+                val blueCheckedUsers = allMentors.filter { it.registered }
+                val tempUsers = allMentors.filterNot { it.registered }
+
+                val sortedBlueCheckedUsers = blueCheckedUsers.sortedBy { it.position }
+                val sortedTempUsers = tempUsers.sortedBy { it.position }
+
+                //TODO 근데 이런 식이면 구현이 드러나는 테스트 코드 아닌가? 개선이 필요해 보임
+                allMentors.filter { it.registered } shouldBe sortedBlueCheckedUsers
+                allMentors.filterNot { it.registered } shouldBe sortedTempUsers
+            }
+        }
+    }
+})

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -175,13 +175,17 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         `when`("조회 요청 메서드 실행 시") {
             val allMentors = queryAllMentorsService.execute()
 
-            then("임시 사용자와 블루체크 된 사용자 중 블루체크된 사용자가 앞에 존재한다") {
+            then("블루체크 된 멘토, 임시 멘토가 결과로 반환되어야 한다") {
                 val blueCheckedUsers = allMentors.filter { it.registered }
                 val tempUsers = allMentors.filterNot { it.registered }
 
-                // 블루체크 된 사용자와 임시 사용자 리스트가 빈 리스트가 아닌지 확인
                 blueCheckedUsers.shouldNotBeEmpty()
                 tempUsers.shouldNotBeEmpty()
+            }
+
+            then("임시 사용자와 블루체크 된 사용자 중 블루체크된 사용자가 앞에 존재한다") {
+                val blueCheckedUsers = allMentors.filter { it.registered }
+                val tempUsers = allMentors.filterNot { it.registered }
 
                 // 블루체크 된 사용자가 먼저 나오는지 확인
                 val firstBlueCheckedUser = blueCheckedUsers.first()

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -168,9 +168,10 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         snsUrl = "https://www.instagram.com/a"
     )
 
-    given("조회할 멘토, 임시 멘토 리스트가 주어질 때") {
+    given("조회할 멘토, 임시 멘토 리스트와 예상 결과 리스트가 주어질 때") {
         every { mentorRepository.findAllMentorInfoDto() } returns dummyMentorInfoDtos
         every { queryTempMentorListService.execute() } returns dummyTempMentorInfoDtos
+        val sortedMentorIds = listOf(2, 1, 3, 4, 13, 10, 12, 11)
 
         `when`("조회 요청 메서드 실행 시") {
             val allMentors = queryAllMentorsService.execute()
@@ -194,11 +195,9 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             }
 
             then("인증(블루체크) 여부(true가 먼저), 직군, 기수, 이름 순 정렬되어 반환된다") {
-                // 더미가 지금 sortedMentorIds 처럼 정렬된 상태가 되도록 구현되어야 함
-                val sortedMentorIds = listOf(2, 1, 3, 4, 13, 10, 12, 11)
-
                 val allMentorIds = allMentors.map { it.id }
 
+                // 실행 결과가 예상 결과 리스트(sortedMentorIds) 처럼 정렬된 상태가 되도록 구현되어야 함
                 allMentorIds shouldBe sortedMentorIds
             }
         }

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -42,7 +42,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             id = 2L,
             name = "김철수",
             email = "kim@gmail.com",
-            generation = 4,
+            generation = 3,
             position = "개발자",
             company = CompanyInfoDto(
                 name = "DEF 회사",
@@ -64,7 +64,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             ),
             sns = "https://www.instagram.com/c",
             profileUrl = "https://www.instagram.com/img/c",
-            registered = false
+            registered = true
         ),
         MentorInfoDto(
             id = 4L,
@@ -88,7 +88,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             firebaseId = "firebase_1",
             name = "임꺽정",
             email = "lim@gmail.com",
-            generation = 2,
+            generation = 3,
             position = "개발자",
             company = CompanyInfoDto(
                 name = "GHI 회사",
@@ -114,7 +114,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             firebaseId = "firebase_3",
             name = "정도전",
             email = "jeong@gmail.com",
-            generation = 4,
+            generation = 3,
             position = "개발자",
             company = CompanyInfoDto(
                 name = "MNO 회사",
@@ -127,7 +127,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             firebaseId = "firebase_4",
             name = "김유신",
             email = "kim@gmail.com",
-            generation = 3,
+            generation = 2,
             position = "개발자",
             company = CompanyInfoDto(
                 name = "PQR 회사",
@@ -137,11 +137,40 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         )
     )
 
-    given("블루 체크 사용자는 상위에 노출, 직군끼리 묶인 형태의 리스트 반환") {
+    val sameUserMentor = MentorInfoDto(
+        id = 1L,
+        name = "홍길동",
+        email = "hong@gmail.com",
+        generation = 3,
+        position = "디자이너",
+        company = CompanyInfoDto(
+            name = "ABC 회사",
+            url = "https://www.abc-company.com"
+        ),
+        sns = "https://www.instagram.com/a",
+        profileUrl = "https://www.instagram.com/img/a",
+        registered = true
+    )
+
+    val sameUserTempMentor = TempMentorInfoDto(
+        id = 14L,
+        firebaseId = "firebase_5",
+        name = "홍길동",
+        email = "hong@gmail.com",
+        generation = 3,
+        position = "디자이너",
+        company = CompanyInfoDto(
+            name = "ABC 회사",
+            url = "https://www.abc-company.com"
+        ),
+        snsUrl = "https://www.instagram.com/a"
+    )
+
+    given("블루체크 여부(true가 먼저), 직군, 기수, 이름(전부 오름차순)을 기준으로 정렬된 리스트 반환") {
         every { mentorRepository.findAllMentorInfoDto() } returns dummyMentorInfoDtos
         every { queryTempMentorListService.execute() } returns dummyTempMentorInfoDtos
 
-        `when`("임시 사용자와 블루체크 된 사용자 조회 시") {
+        `when`("조회 요청 메서드 실행 시") {
             val allMentors = queryAllMentorsService.execute()
 
             then("블루체크 된 사용자들이 반환 순서의 앞쪽에 위치한다") {
@@ -163,16 +192,38 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
                 dummyTempMentorInfoDtos.forEach { it.id shouldBeIn tempUserIds }
             }
 
-            then("임시 사용자와 블루체크 된 사용자 각각 직군을 기준으로 정렬된 상태를 가진다") {
+            then("임시 사용자와 블루체크 된 사용자 각각 직군, 기수, 이름(전부 오름차순)을 기준으로 정렬된 상태를 가진다") {
                 val blueCheckedUsers = allMentors.filter { it.registered }
                 val tempUsers = allMentors.filterNot { it.registered }
 
-                val sortedBlueCheckedUsers = blueCheckedUsers.sortedBy { it.position }
-                val sortedTempUsers = tempUsers.sortedBy { it.position }
-
                 //TODO 근데 이런 식이면 구현이 드러나는 테스트 코드 아닌가? 개선이 필요해 보임
+                val sortedBlueCheckedUsers = blueCheckedUsers.sortedWith(compareBy({ it.registered }, { it.position }, { it.generation }, { it.name }))
+                val sortedTempUsers = tempUsers.sortedWith(compareBy({ it.registered }, { it.position }, { it.generation }, { it.name }))
+
                 allMentors.filter { it.registered } shouldBe sortedBlueCheckedUsers
                 allMentors.filterNot { it.registered } shouldBe sortedTempUsers
+            }
+        }
+    }
+
+    given("블루체크 된 사용자와 임시 사용자의 정보가 동일한 경우, 블루체크 된 사용자 정보만 반환") {
+        every { mentorRepository.findAllMentorInfoDto() } returns listOf(sameUserMentor)
+        every { queryTempMentorListService.execute() } returns listOf(sameUserTempMentor)
+
+        `when`("조회 요청 메서드 실행 시") {
+            val allMentors = queryAllMentorsService.execute()
+
+            then("임시 사용자와 블루체크 된 사용자 정보가 중복된다면, 블루체크 된 사용자만 반환") {
+                val blueCheckedUsers = allMentors.filter { it.registered }
+
+                blueCheckedUsers.size shouldBe 1
+
+                val firstBlueCheckedUser = blueCheckedUsers.firstOrNull()
+                firstBlueCheckedUser shouldNotBe null
+
+                firstBlueCheckedUser!!.id shouldBe sameUserMentor.id
+                firstBlueCheckedUser.name shouldBe sameUserMentor.name
+                firstBlueCheckedUser.email shouldBe sameUserMentor.email
             }
         }
     }

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -189,9 +189,9 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
                 allMentors.indexOf(firstBlueCheckedUser) should beLessThan(allMentors.indexOf(firstTempUser))
             }
 
-            then("인증(블루체크) 여부, 직군, 기수, 이름 순 정렬되어 반환된다") {
+            then("인증(블루체크) 여부(ture가 먼저), 직군, 기수, 이름 순 정렬되어 반환된다") {
                 val sortedMentors = allMentors.sortedWith(
-                    compareBy({ it.registered }, { it.position }, { it.generation }, { it.name })
+                    compareBy({ !it.registered }, { it.position }, { it.generation }, { it.name })
                 )
 
                 allMentors shouldBe sortedMentors

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -1,8 +1,6 @@
 package team.themoment.gsmNetworking.domain.mentor.service
 
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldBeIn
-import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.beLessThan
 import io.kotest.matchers.should
@@ -170,7 +168,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         snsUrl = "https://www.instagram.com/a"
     )
 
-    given("블루체크 여부(true가 먼저), 직군, 기수, 이름(전부 오름차순)을 기준으로 정렬된 리스트 반환") {
+    given("조회할 멘토, 임시 멘토 리스트가 주어질 때") {
         every { mentorRepository.findAllMentorInfoDto() } returns dummyMentorInfoDtos
         every { queryTempMentorListService.execute() } returns dummyTempMentorInfoDtos
 
@@ -201,7 +199,7 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         }
     }
 
-    given("블루체크 된 사용자와 임시 사용자의 정보가 동일한 경우, 블루체크 된 사용자 정보만 반환") {
+    given("같은 사용자 정보를 가지는 멘토, 임시 멘토가 주어질 때") {
         every { mentorRepository.findAllMentorInfoDto() } returns listOf(sameUserMentor)
         every { queryTempMentorListService.execute() } returns listOf(sameUserTempMentor)
 

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -189,12 +189,13 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
                 allMentors.indexOf(firstBlueCheckedUser) should beLessThan(allMentors.indexOf(firstTempUser))
             }
 
-            then("인증(블루체크) 여부(ture가 먼저), 직군, 기수, 이름 순 정렬되어 반환된다") {
-                val sortedMentors = allMentors.sortedWith(
-                    compareBy({ !it.registered }, { it.position }, { it.generation }, { it.name })
-                )
+            then("인증(블루체크) 여부(true가 먼저), 직군, 기수, 이름 순 정렬되어 반환된다") {
+                // 더미가 지금 sortedMentorIds 처럼 정렬된 상태가 되도록 구현되어야 함
+                val sortedMentorIds = listOf(2, 1, 3, 4, 13, 10, 12, 11)
 
-                allMentors shouldBe sortedMentors
+                val allMentorIds = allMentors.map { it.id }
+
+                allMentorIds shouldBe sortedMentorIds
             }
         }
     }


### PR DESCRIPTION
#### 1. 모든 맨토 조회 시 id가 올바르게 할당되지 않는 문제를 수정하였습니다.

#### 2. 리스트를 정렬된 상태로 반환하도록 구현하였습니다. 
구현 기준: 블루체크 여부, 직군, 기수, 이름

#### 3. `QueryAllMentorsListService `-> `QueryAllMentorsService` 이름을 변경하고, 인터페이스를 사용하도록 변경하였습니다.

#### 4. `QueryAllMentorsService`의 테스트 코드를 구현하였습니다.