### PR TITLE
session을 stateless로 설정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
@@ -41,6 +42,9 @@ class SecurityConfig(
             .httpBasic().disable()
             .csrf().disable()
             .cors().configurationSource(corsConfigurationSource())
+            .and()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .apply(FilterConfig(tokenRequestFilter, exceptionHandlerFilter, loggingFilter))
         logout(http)


### PR DESCRIPTION
## 개요

session을 stateless로 설정하였습니다.

## 본문

accessToken이 없는 상태로 멘토 리스트 등의 자원에 요청했을시 제대로 반환을 하는 등의 인증인가 부분의 문제가 있었습니다.
Jsession이 인증 인가를 대신 하는 문제가 있어서 session을 stateless로 설정하였습니다.