### PR TITLE
멘토 정보 삭제시 임시 멘토 삭제 취소

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -6,7 +6,6 @@ import javax.persistence.*
 
 @Entity
 @Table(name = "temp_mentor")
-@Where(clause = "deleted = false")
 class TempMentor(
     @Id
     @Column(name = "real_id")

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/TempMentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/TempMentorRepository.kt
@@ -8,8 +8,12 @@ import team.themoment.gsmNetworking.domain.mentor.domain.TempMentor
  */
 interface TempMentorRepository : CrudRepository<TempMentor, Long> {
 
-    fun findByName(name: String): List<TempMentor>
+    fun findAllByDeletedIsFalse(): List<TempMentor>
+
+    fun findAllByName(name: String): List<TempMentor>
 
     fun findByFirebaseId(firebaseId: String): TempMentor?
+
+    fun findByGenerationAndName(generation: Int, name: String): TempMentor?
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
@@ -37,7 +37,7 @@ class DeleteMyMentorInfoService(
             ?: throw ExpectedException("존재하지 않는 user입니다.", HttpStatus.NOT_FOUND)
         val mentor = mentorRepository.findByUser(user)
             ?: throw ExpectedException("존재하지 않는 mentor입니다.", HttpStatus.NOT_FOUND)
-        tempMentorRepository.findByGenerationAndName(mentor.user.generation, mentor.user.name)
+        tempMentorRepository.findByGenerationAndName(user.generation, user.name)
             ?.let { it.deleted = false }
 
         deleteMyInfo(user, mentor)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteMyMentorInfoService.kt
@@ -6,8 +6,12 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.common.exception.ExpectedException
 import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
 import team.themoment.gsmNetworking.domain.auth.domain.Authority
+import team.themoment.gsmNetworking.domain.mentor.domain.Mentor
+import team.themoment.gsmNetworking.domain.mentor.domain.TempMentor
 import team.themoment.gsmNetworking.domain.mentor.repository.CareerRepository
 import team.themoment.gsmNetworking.domain.mentor.repository.MentorRepository
+import team.themoment.gsmNetworking.domain.mentor.repository.TempMentorRepository
+import team.themoment.gsmNetworking.domain.user.domain.User
 import team.themoment.gsmNetworking.domain.user.repository.UserRepository
 
 /**
@@ -19,6 +23,7 @@ class DeleteMyMentorInfoService(
     private val userRepository: UserRepository,
     private val mentorRepository: MentorRepository,
     private val careerRepository: CareerRepository,
+    private val tempMentorRepository: TempMentorRepository,
     private val authenticatedUserManager: AuthenticatedUserManager
 ) {
 
@@ -32,7 +37,13 @@ class DeleteMyMentorInfoService(
             ?: throw ExpectedException("존재하지 않는 user입니다.", HttpStatus.NOT_FOUND)
         val mentor = mentorRepository.findByUser(user)
             ?: throw ExpectedException("존재하지 않는 mentor입니다.", HttpStatus.NOT_FOUND)
+        tempMentorRepository.findByGenerationAndName(mentor.user.generation, mentor.user.name)
+            ?.let { it.deleted = false }
 
+        deleteMyInfo(user, mentor)
+    }
+
+    private fun deleteMyInfo(user: User, mentor: Mentor) {
         careerRepository.deleteByMentor(mentor)
         mentorRepository.deleteByUser(user)
         userRepository.deleteById(user.userId)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListByNameService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListByNameService.kt
@@ -22,7 +22,7 @@ class QueryTempMentorListByNameService(
      * @return 가져온 임시멘토 정보가 담긴 dto
      */
     fun execute(name: String): List<SearchTempMentorInfoDto> {
-        val searchTempMentors = tempMentorRepository.findByName(name).map { tempMentor ->
+        val searchTempMentors = tempMentorRepository.findAllByName(name).map { tempMentor ->
             SearchTempMentorInfoDto(
                 tempMentor.id,
                 tempMentor.firebaseId,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListService.kt
@@ -21,7 +21,7 @@ class QueryTempMentorListService(
      * @return 임시멘토 정보가 담긴 dto
      */
     fun execute(): List<TempMentorInfoDto> {
-        val tempMentors = tempMentorRepository.findAll().map { tempMentor ->
+        val tempMentors = tempMentorRepository.findAllByDeletedIsFalse().map { tempMentor ->
             TempMentorInfoDto(
                 tempMentor.id,
                 tempMentor.firebaseId,


### PR DESCRIPTION
## 개요

멘토 정보 삭제시 임시 멘토 삭제를 취소하였습니다.

## 본문

멘토 정보 삭제시 임시 멘토를 연동한 사용자 이면 연동할때 삭제했던 임시멘토를 다시 되돌리도록 구현하였습니다.