### PR TITLE
모든 멘토 리스트에서 잘못된 값을 반환하는 코드 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/QueryAllMentorsServiceImpl.kt
@@ -29,9 +29,8 @@ class QueryAllMentorsServiceImpl(
                 .map(TempMentorInfoDto::toMentorInfoDto))
                 .distinctBy { Pair(it.generation, it.name) }
                 .sortedWith(compareBy({ !it.registered }, { it.position }, { it.generation }, { it.name }))
-        generateNewMentorIds(allMentors)
 
-        return allMentors
+        return generateNewMentorIds(allMentors)
     }
 
     private fun generateNewMentorIds(allMentors: List<MentorInfoDto>): List<MentorInfoDto> =

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -171,7 +171,8 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
     given("조회할 멘토, 임시 멘토 리스트와 예상 결과 리스트가 주어질 때") {
         every { mentorRepository.findAllMentorInfoDto() } returns dummyMentorInfoDtos
         every { queryTempMentorListService.execute() } returns dummyTempMentorInfoDtos
-        val sortedMentorIds = listOf(2, 1, 3, 4, 13, 10, 12, 11)
+        val sortedMentorNames = listOf("김철수", "홍길동", "이영희", "박철호", "김유신", "임꺽정", "정도전", "유관순")
+        val sortedMentorIds = listOf(1, 2, 3, 4, 5, 6, 7, 8)
 
         `when`("조회 요청 메서드 실행 시") {
             val allMentors = queryAllMentorsService.execute()
@@ -195,6 +196,13 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
             }
 
             then("인증(블루체크) 여부(true가 먼저), 직군, 기수, 이름 순 정렬되어 반환된다") {
+                val allMentorNames = allMentors.map { it.name }
+
+                // 실행 결과가 예상 결과 리스트(sortedMentorIds) 처럼 정렬된 상태가 되도록 구현되어야 함
+                allMentorNames shouldBe sortedMentorNames
+            }
+
+            then("id가 1부터 재할당되어 반환된다") {
                 val allMentorIds = allMentors.map { it.id }
 
                 // 실행 결과가 예상 결과 리스트(sortedMentorIds) 처럼 정렬된 상태가 되도록 구현되어야 함


### PR DESCRIPTION
## 개요

모든 멘토 리스트에서 id를 재할당하지 않은 객체를 반환하고있어서 수정하였습니다.