### PR TITLE
채팅 기능 domain&repository 객체 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/StompPathUtil.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/StompPathUtil.kt
@@ -2,12 +2,12 @@ package team.themoment.gsmNetworking.common.util
 
 class StompPathUtil {
     companion object {
-        const val PREFIX_TO_ROOM = "/topic/room"
-        // /queue/user/{sessionId} 로 요청 보냄
-        const val PREFIX_TO_USER = "/queue/user"
+        const val PREFIX_TOPIC_MESSAGE_HEADER = "/topic/messaging"
+        // /queue/user/{sessionId} 로 요청 보낼때 사용
+        const val PREFIX_QUEUE_USER = "/queue/user"
 
         fun getAllPrefix(): List<String> {
-            return listOf(PREFIX_TO_ROOM, PREFIX_TO_USER)
+            return listOf(PREFIX_TOPIC_MESSAGE_HEADER, PREFIX_QUEUE_USER)
         }
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.common.util
 
+import com.fasterxml.uuid.Generators
 import java.time.*
 import java.util.*
 
@@ -10,6 +11,13 @@ class UUIDUtils {
 
         val MAX_TIME: Instant = Instant.ofEpochMilli(MAX_EPOCH_MILLIS)
         val MIN_TIME: Instant = Instant.ofEpochMilli(MIN_EPOCH_MILLIS)
+
+        /**
+         * v7 UUID를 생성합니다.
+         *
+         * @return v7 UUID
+         */
+        fun generateUUIDv7(): UUID = Generators.timeBasedEpochGenerator().generate()
 
         /**
          * 주어진 epoch 밀리초를 사용하여 가장 작은 v7 UUID를 생성합니다.

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/util/UUIDUtils.kt
@@ -22,8 +22,8 @@ class UUIDUtils {
         /**
          * 주어진 epoch 밀리초를 사용하여 가장 작은 v7 UUID를 생성합니다.
          *
-         * @param epochMilli 특정 시간을 나타내는 epoch 밀리초 값입니다.
-         * @return epoch 밀리초에서 생성된 가장 작은 v7 UUID입니다.
+         * @param epochMilli 특정 시간을 나타내는 epoch 밀리초 값
+         * @return epoch 밀리초에서 생성된 가장 작은 v7 UUID
          */
         private fun generateSmallestUUIDv7(epochMilli: Long): UUID {
             // 지정된 위치에 '-'를 삽입하여 포맷된 UUID 문자열을 생성합니다.

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Header.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Header.kt
@@ -1,0 +1,49 @@
+package team.themoment.gsmNetworking.domain.message.domain
+
+import java.util.UUID
+import javax.persistence.*
+
+
+@Entity
+@Table(
+    name = "header", indexes = [Index(name = "idx_user1_user2", columnList = "user1_id, user2_id", unique = true),
+        Index(name = "idx_user2_time", columnList = "user2_id, recent_message_id desc", unique = true),
+        Index(name = "idx_user1_time", columnList = "user1_id, recent_message_id desc", unique = true)]
+)
+// Header는 Message에 의존적임.
+// Message의 빠른 조회를 위해 비정규화 된 값 값이라고 봐도 됨
+class Header private constructor(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "header_id")
+    val headerId: Long = 0,
+
+    @Column(name = "user1_id", nullable = false)
+    val user1Id: Long,
+
+    @Column(name = "user2_id", nullable = false)
+    val user2Id: Long,
+
+    @Column(name = "recent_message_id", columnDefinition = "BINARY(16)", unique = true, nullable = false)
+    val recentMessageId: UUID
+) {
+    init {
+        require(user1Id != user2Id) { "user1Id and user2Id must be different" }
+        require(user1Id < user2Id) { "user1Id must be smaller than user2Id" }
+    }
+
+    constructor(user1Id: Long, user2Id: Long, recentChatId: UUID) : this(
+        headerId = 0,
+        user1Id = minOf(user1Id, user2Id),
+        user2Id = maxOf(user1Id, user2Id),
+        recentMessageId = recentChatId
+    )
+
+    fun copyWithNewRecentChatId(header: Header, newRecentChatId: UUID): Header {
+        return Header(
+            headerId = this.headerId,
+            user1Id = this.user1Id,
+            user2Id = this.user2Id,
+            recentMessageId = newRecentChatId
+        )
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Message.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Message.kt
@@ -1,0 +1,57 @@
+package team.themoment.gsmNetworking.domain.message.domain
+
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import java.util.UUID
+import javax.persistence.*
+
+@Entity
+@Table(
+    name = "message",
+    indexes = [Index(name = "idx_user1_user2", columnList = "user1_id, user2_id, message_id desc", unique = true)]
+)
+class Message private constructor(
+    @Id @Column(name = "message_id", columnDefinition = "BINARY(16)")
+    val messageId: UUID = UUIDUtils.generateUUIDv7(),
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "header_id", nullable = false)
+    val header: Header,
+
+    @Column(name = "user1_id", nullable = false)
+    val user1Id: Long,
+
+    @Column(name = "user2_id", nullable = false)
+    val user2Id: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false)
+    val direction: MessageDirection,
+
+    @Column(name = "content", nullable = false)
+    val content: String
+) {
+
+    init {
+        require(user1Id != user2Id) { "user1Id and user2Id must be different" }
+        require(user1Id < user2Id) { "user1Id must be smaller than user2Id" }
+    }
+
+    constructor(
+        messageId: UUID = UUIDUtils.generateUUIDv7(),
+        header: Header,
+        direction: MessageDirection,
+        content: String
+    ) : this(
+        messageId = messageId,
+        header = header,
+        user1Id = header.user1Id,
+        user2Id = header.user2Id,
+        direction = direction,
+        content = content
+    )
+
+    enum class MessageDirection {
+        ToUser1,
+        ToUser2
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
@@ -1,0 +1,26 @@
+package team.themoment.gsmNetworking.domain.message.domain
+
+import java.util.UUID
+import javax.persistence.*
+
+@Entity
+@Table(
+    name = "user_message_info",
+    indexes = [Index(name = "idx_user_id_opponent_user_id", columnList = "user_id, opponent_user_id", unique = true)]
+)
+class UserMessageInfo(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_message_info_id")
+    val userMessageInfoId: Long = 0,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(name = "opponent_user_id", nullable = false)
+    val opponentUserId: Long,
+
+    // 생성되었지만, 특정 사용자외의 메시지를 한번도 확인하지 않은 경우 null 상태를 가짐
+    @Column(name = "last_viewed_message_id", columnDefinition = "BINARY(16)")
+    val lastViewedMessageId: UUID?
+) {
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageDto.kt
@@ -1,0 +1,12 @@
+package team.themoment.gsmNetworking.domain.message.dto.domain
+
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import java.util.*
+
+data class MessageDto(
+    val messageId: UUID,
+    val user1Id: Long,
+    val user2Id: Long,
+    val direction: Message.MessageDirection,
+    val content: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageMetaDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageMetaDto.kt
@@ -1,0 +1,12 @@
+package team.themoment.gsmNetworking.domain.message.dto.domain
+
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import java.util.UUID
+
+data class MessageMetaDto(
+    val user1Id: Long,
+    val user2Id: Long,
+    val messageDirection: Message.MessageDirection,
+    val recentMessageId: UUID,
+    val lastViewedChatId: UUID?
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/enums/QueryDirection.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/enums/QueryDirection.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.enums
+
+enum class QueryDirection {
+    PREVIOUS,
+    NEXT
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/HeaderRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/HeaderRepository.kt
@@ -1,0 +1,9 @@
+package team.themoment.gsmNetworking.domain.message.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.message.domain.Header
+
+
+interface HeaderRepository : CrudRepository<Header, Long> {
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepository.kt
@@ -1,0 +1,48 @@
+package team.themoment.gsmNetworking.domain.message.repository
+
+import team.themoment.gsmNetworking.domain.message.domain.Header
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageMetaDto
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
+import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
+import java.time.Instant
+
+interface MessageCustomRepository {
+
+    /**
+     * 특정 사용자의 특정 시간 이전에 채팅이 발생한 채팅 정보 목록을 일부 조회합니다.
+     *
+     * @param userId 사용자의 고유 식별자
+     * @param time 필터링에 사용될 시간
+     * @param limit 반환할 결과의 개수
+     * @return [MessageMetaDto] 목록
+     */
+    fun findMessageInfosByUserId(userId: Long, time: Instant, limit: Long): List<MessageMetaDto>
+
+    /**
+     * 두 사용자 간의 채팅 목록을 가져옵니다. 특정 시간을 기준으로 이전, 이후 데이터를 일부 조회합니다.
+     *
+     * @param user1Id 사용자1의 고유 식별자
+     * @param user2Id 사용자2의 고유 식별자
+     * @param time 조회의 기준이 되는 시간
+     * @param direction 특정 시간을 기준으로 이전, 이후 데이터를 불러올지 결정하는 값
+     * @param limit 반환할 결과의 개수
+     * @return [MessageDto] 목록
+     */
+    fun findMessagesBetweenUsers(
+        user1Id: Long,
+        user2Id: Long,
+        time: Instant,
+        limit: Long,
+        direction: QueryDirection
+    ): List<MessageDto>
+
+    /**
+     * 두 사용자 간의 채팅 정보를 가져옵니다.
+     *
+     * @param user1Id 사용자1의 고유 식별자
+     * @param user2Id 사용자2의 고유 식별자
+     * @return nullable [Message]
+     */
+    fun findHeaderBetweenUsers(user1Id: Long, user2Id: Long): Header?
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepositoryImpl.kt
@@ -1,0 +1,94 @@
+package team.themoment.gsmNetworking.domain.message.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import team.themoment.gsmNetworking.domain.message.domain.Header
+import team.themoment.gsmNetworking.domain.message.domain.QHeader.header
+import team.themoment.gsmNetworking.domain.message.domain.QMessage.message
+import team.themoment.gsmNetworking.domain.message.domain.QUserMessageInfo.userMessageInfo
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageMetaDto
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
+import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
+import java.time.Instant
+
+
+class MessageCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : MessageCustomRepository {
+    override fun findMessageInfosByUserId(userId: Long, time: Instant, limit: Long): List<MessageMetaDto> =
+        queryFactory
+            .select(
+                Projections.constructor(
+                    MessageMetaDto::class.java,
+                    header.user1Id,
+                    header.user2Id,
+                    message.direction,
+                    header.recentMessageId,
+                    userMessageInfo.lastViewedMessageId
+                )
+            )
+            .from(header)
+            .innerJoin(message)
+            .on(
+                header.user1Id.eq(userId).or(header.user2Id.eq(userId)),
+                recentChatIdLt(time),
+                message.messageId.eq(header.recentMessageId),
+            )
+            .innerJoin(userMessageInfo)
+            .on(
+                userMessageInfo.userId.eq(userId),
+                (userMessageInfo.opponentUserId.`in`(header.user1Id, header.user2Id))
+            )
+            .orderBy(header.recentMessageId.desc())
+            .limit(limit)
+            .fetch()
+
+    override fun findMessagesBetweenUsers(
+        user1Id: Long,
+        user2Id: Long,
+        time: Instant,
+        limit: Long,
+        direction: QueryDirection
+    ): List<MessageDto> {
+        val timeCondition = when (direction) {
+            QueryDirection.NEXT -> recentChatIdLt(time)
+            QueryDirection.PREVIOUS -> message.messageId.goe(UUIDUtils.generateSmallestUUIDv7(time))
+        }
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    MessageDto::class.java,
+                    message.messageId,
+                    message.user1Id,
+                    message.user2Id,
+                    message.direction,
+                    message.content
+                )
+            )
+            .from(message)
+            .where(
+                message.user1Id.eq(user1Id),
+                message.user2Id.eq(user2Id),
+                timeCondition
+            )
+            .orderBy(message.messageId.desc())
+            .limit(limit)
+            .fetch()
+    }
+
+    override fun findHeaderBetweenUsers(user1Id: Long, user2Id: Long): Header? =
+        queryFactory
+            .selectFrom(header)
+            .where(
+                header.user1Id.eq(user1Id),
+                header.user2Id.eq(user2Id)
+            )
+            .fetchOne()
+
+    private fun recentChatIdLt(time: Instant): BooleanExpression =
+        // 입력받은 시간 + 1을 미만 조건으로 검색
+        header.recentMessageId.lt(UUIDUtils.generateSmallestUUIDv7(time.plusMillis(1)))
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageRepository.kt
@@ -1,0 +1,9 @@
+package team.themoment.gsmNetworking.domain.message.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.message.domain.Message
+
+
+interface MessageRepository : CrudRepository<Message, Long>, MessageCustomRepository {
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
@@ -1,0 +1,10 @@
+package team.themoment.gsmNetworking.domain.message.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.themoment.gsmNetworking.domain.message.domain.UserMessageInfo
+
+
+interface UserMessageInfoRepository : CrudRepository<UserMessageInfo, Long> {
+    fun findByUserId(userId: Long): UserMessageInfo?
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/socket/sender/StompSenderImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/socket/sender/StompSenderImpl.kt
@@ -34,7 +34,7 @@ class StompSenderImpl(
     }
 
     override fun sendMessageToSession(message: StompMessage<*>, sessionId: String) {
-        val path = "${StompPathUtil.PREFIX_TO_USER}/$sessionId"
+        val path = "${StompPathUtil.PREFIX_QUEUE_USER}/$sessionId"
 
         // isSessionSubscribedToPath를 쓰면 Apic으로 테스트가 불가능, Apic은 한 session이 한 sub만 가능함
         // TODO 위 문제 해결하고 isSessionSubscribedToPath 사용하게 변경
@@ -48,7 +48,7 @@ class StompSenderImpl(
 
     private fun getSubscriptionUrls(userId: Long): List<String> {
         return connectedInfoRepository.findByUserId(userId)
-            .flatMap { connect -> connect.subscribes.filter { it.subscribeUrl.contains(StompPathUtil.PREFIX_TO_USER) } }
+            .flatMap { connect -> connect.subscribes.filter { it.subscribeUrl.contains(StompPathUtil.PREFIX_QUEUE_USER) } }
             .map { it.subscribeUrl }
     }
 


### PR DESCRIPTION
## 개요
채팅 기능에 사용되는 domain, repository, 그 외 기타 객체를 구현하였습니다.
그 외 STOMP 관련 기능이 추가되었습니다.

## 설명

#### StompPathUtil Path 변경
이름과 주소가 변경되었습니다.

#### UUIDUtils#generateUUIDv7 추가
도메인에서 직접 서드파티 라이브러리를 호출해야 하는 문제가 있었습니다.
Util을 사용하여 호출하여 직접적인 의존성 없이 v7 UUID를 사용할 수 있게 변경하였습니다.

#### 채팅 관련 domain & repository 객체 구현
관련된 DTO, Enum 객체도 추가되었습니다.

**domain 객체 설명:**
- `Message` : 메시지
- `Header` : 사용자 사이의 채팅 관련 메타 정보 저장
- `UserMessageInfo` : 사용자 별 채팅 관련 정보

## 주의사항
repository는 추후에 구현이 변경될 수 있으므로 내부 메서드에 대한 리뷰는 생략하셔도 됩니다.
구현이 완료되면 KDoc 추가하도록 하겠습니다.