### PR TITLE
채팅 API 및 비즈니스 로직 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
@@ -1,19 +1,18 @@
 package team.themoment.gsmNetworking.common.socket.message
 
 enum class GlobalMessageCode(
-    private val _supportClass: Class<out Any>
+    private val supportClass: Class<out Any>
 ) : MessageCode {
     ERROR(StompMessage::class.java);
 
-    override fun code(): String {
-        return name
-    }
+    override val code: String
+        get() = name
 
     override fun isSupportClass(clazz: Class<out Any>): Boolean {
-        return this._supportClass.isAssignableFrom(clazz)
+        return this.supportClass.isAssignableFrom(clazz)
     }
 
-    override fun supportClass(): Class<out Any> {
-        return this._supportClass
+    override fun getSupportClass(): Class<out Any> {
+        return this.supportClass
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
@@ -1,9 +1,19 @@
 package team.themoment.gsmNetworking.common.socket.message
 
-enum class GlobalMessageCode : MessageCode {
-    ERROR;
+enum class GlobalMessageCode(
+    private val _supportClass: Class<out Any>
+) : MessageCode {
+    ERROR(StompMessage::class.java);
 
     override fun code(): String {
         return name
+    }
+
+    override fun isSupportClass(clazz: Class<out Any>): Boolean {
+        return this._supportClass.isAssignableFrom(clazz)
+    }
+
+    override fun supportClass(): Class<out Any> {
+        return this._supportClass
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
@@ -1,0 +1,9 @@
+package team.themoment.gsmNetworking.common.socket.message
+
+enum class GlobalMessageCode : MessageCode {
+    ERROR;
+
+    override fun code(): String {
+        return name
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
@@ -1,0 +1,5 @@
+package team.themoment.gsmNetworking.common.socket.message
+
+interface MessageCode {
+    fun code(): String
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
@@ -1,5 +1,26 @@
 package team.themoment.gsmNetworking.common.socket.message
 
 interface MessageCode {
+
+    /**
+     * 메시지와 연관된 코드를 가져옵니다. 코드는 구현체 사이의 중복이 발생하지 않는 식별 가능한 값 이여야 합니다.
+     *
+     * @return 코드
+     */
     fun code(): String
+
+    /**
+     * 제공된 클래스가 메시지 코드에서 지원되는지 확인합니다.
+     *
+     * @param clazz 지원 여부를 확인할 클래스입니다.
+     * @return 제공된 클래스가 지원 클래스로부터 할당 가능한 경우 `true`, 그렇지 않은 경우 `false`
+     */
+    fun isSupportClass(clazz: Class<out Any>): Boolean
+
+    /**
+     * 지원하는 클래스 정보를 반환합니다.
+     *
+     * @return 지원 클래스
+     */
+    fun supportClass(): Class<out Any>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/MessageCode.kt
@@ -7,7 +7,7 @@ interface MessageCode {
      *
      * @return 코드
      */
-    fun code(): String
+    val code: String
 
     /**
      * 제공된 클래스가 메시지 코드에서 지원되는지 확인합니다.
@@ -22,5 +22,5 @@ interface MessageCode {
      *
      * @return 지원 클래스
      */
-    fun supportClass(): Class<out Any>
+    fun getSupportClass(): Class<out Any>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
@@ -3,7 +3,7 @@ package team.themoment.gsmNetworking.common.socket.message
 /**
  * STOMP 메시지를 사용자에게 전달하기 위한 Wrapper 객체입니다.
  */
-class StompMessage<T>(
+class StompMessage<T : Any>(
     val content: T,
     private val _messageCode: MessageCode,
     val messageType: MessageType = MessageType.MESSAGE
@@ -11,6 +11,22 @@ class StompMessage<T>(
     enum class MessageType {
         ERROR,
         MESSAGE
+    }
+
+    // TODO 지금은 구현을 못했지만 content만 입력 받아도 적절한 _messageCode를 자동으로 할당되도록 구현했으면 좋겠다.
+    //  지금은 임시로 _messageCode가 content Class를 지원하는지 확인하도록 구현하였음
+    //  ---
+    //  원하는 구현 예시
+    //      사용하는 측에서 StompMessage(abcContent) 로만 사용해도 동작하도록
+    //      지금은 StompMessage(abcContent, AbcMessageCode.ABC) 이런식으로 사용하는 쪽에서 직접 Type을 지정해 주어여 함
+    init {
+        require(
+            _messageCode.isSupportClass(content::class.java)
+        ) {
+            "사용 된 content의 Type을 지원하지 않는 MessageCode 입니다. " +
+                    "올바른 MessageCode를 사용해 주세요. " +
+                    "해당 객체 생성자에 사용된 MessageCode, $_messageCode 는 ${_messageCode.supportClass()} 클래스를 지원합니다."
+        }
     }
 
     val messageCode: String

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
@@ -5,9 +5,12 @@ package team.themoment.gsmNetworking.common.socket.message
  */
 class StompMessage<T : Any>(
     val content: T,
-    private val _messageCode: MessageCode,
+    private val internalMessageCode: MessageCode,
     val messageType: MessageType = MessageType.MESSAGE
 ) {
+    val messageCode: String
+        get() = internalMessageCode.code
+
     enum class MessageType {
         ERROR,
         MESSAGE
@@ -21,15 +24,12 @@ class StompMessage<T : Any>(
     //      지금은 StompMessage(abcContent, AbcMessageCode.ABC) 이런식으로 사용하는 쪽에서 직접 Type을 지정해 주어여 함
     init {
         require(
-            _messageCode.isSupportClass(content::class.java)
+            internalMessageCode.isSupportClass(content::class.java)
         ) {
             "사용 된 content의 Type을 지원하지 않는 MessageCode 입니다. " +
                     "올바른 MessageCode를 사용해 주세요. " +
-                    "해당 객체 생성자에 사용된 MessageCode, $_messageCode 는 ${_messageCode.supportClass()} 클래스를 지원합니다."
+                    "해당 객체 생성자에 사용된 MessageCode, $internalMessageCode 는 ${internalMessageCode.getSupportClass()} 클래스를 지원합니다."
         }
     }
-
-    val messageCode: String
-        get() = _messageCode.code()
 }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/StompMessage.kt
@@ -5,10 +5,15 @@ package team.themoment.gsmNetworking.common.socket.message
  */
 class StompMessage<T>(
     val content: T,
+    private val _messageCode: MessageCode,
     val messageType: MessageType = MessageType.MESSAGE
 ) {
     enum class MessageType {
         ERROR,
         MESSAGE
     }
+
+    val messageCode: String
+        get() = _messageCode.code()
 }
+

--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
@@ -1,6 +1,7 @@
 package team.themoment.gsmNetworking.common.socket.sender
 
 import team.themoment.gsmNetworking.common.exception.StompException
+import team.themoment.gsmNetworking.common.socket.message.GlobalMessageCode
 import team.themoment.gsmNetworking.common.socket.message.StompMessage
 import team.themoment.gsmNetworking.common.socket.model.StompErrorResponse
 
@@ -67,6 +68,6 @@ interface StompSender {
      * @return 에러 메시지
      */
     fun createErrorMessage(ex: StompException): StompMessage<StompErrorResponse> =
-        StompMessage(StompErrorResponse(ex.code, ex.message))
+        StompMessage(StompErrorResponse(ex.code, ex.message), GlobalMessageCode.ERROR)
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageHttpController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageHttpController.kt
@@ -1,0 +1,27 @@
+package team.themoment.gsmNetworking.domain.message.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.domain.message.dto.api.req.*
+import team.themoment.gsmNetworking.domain.message.dto.domain.HeaderDto
+import team.themoment.gsmNetworking.domain.message.service.QueryMessageService
+
+@RestController
+@RequestMapping("api/v1/message")
+class MessageHttpController(
+    private val queryMessageService: QueryMessageService
+) {
+    @GetMapping("/header")
+    fun getMetaMessage(@RequestBody req: QueryHeaderReq): ResponseEntity<HeaderDto?> {
+        val headerDto = queryMessageService.getHeaderByUserIds(req.user1Id, req.user2Id)
+        return if (headerDto == null) {
+            ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        } else {
+            ResponseEntity.status(HttpStatus.OK).body(headerDto)
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
@@ -100,7 +100,7 @@ class MessageWebsocketController(
             val headerResponses =
                 queryMessageService.getMessageInfosByUserId(userId, Instant.ofEpochMilli(req.epochMilli), req.limit)
 
-            stompSender.sendMessageToSession(StompMessage(headerResponses, MessageMessageCode.HEADERS), sessionId)
+            stompSender.sendMessageToSession(StompMessage(HeadersRes(headerResponses), MessageMessageCode.HEADERS), sessionId)
 
         } catch (ex: RuntimeException) {
             stompSender.sendErrorMessageToSession(
@@ -127,7 +127,7 @@ class MessageWebsocketController(
                 req.direction
             )
 
-            stompSender.sendMessageToSession(StompMessage(messageResponses, MessageMessageCode.MESSAGES), sessionId)
+            stompSender.sendMessageToSession(StompMessage(MessagesRes(messageResponses), MessageMessageCode.MESSAGES), sessionId)
 
         } catch (ex: RuntimeException) {
             stompSender.sendErrorMessageToSession(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
@@ -1,0 +1,141 @@
+package team.themoment.gsmNetworking.domain.message.controller
+
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.common.socket.sender.StompSender
+import team.themoment.gsmNetworking.common.exception.StompException
+import team.themoment.gsmNetworking.common.exception.model.ErrorCode
+import team.themoment.gsmNetworking.common.socket.message.StompMessage
+import team.themoment.gsmNetworking.common.util.StompPathUtil
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import team.themoment.gsmNetworking.domain.message.dto.api.req.*
+import team.themoment.gsmNetworking.domain.message.dto.api.res.*
+import team.themoment.gsmNetworking.domain.message.service.CheckMessageService
+import team.themoment.gsmNetworking.domain.message.service.QueryMessageService
+import team.themoment.gsmNetworking.domain.message.service.SaveMessageService
+import java.security.Principal
+import java.time.Instant
+
+@RestController
+class MessageWebsocketController(
+    private val stompSender: StompSender,
+    private val saveMessageService: SaveMessageService,
+    private val checkMessageService: CheckMessageService,
+    private val queryMessageService: QueryMessageService
+) {
+    @MessageMapping("/message")
+    fun sendMessage(
+        @Payload req: SaveMessageReq,
+        principal: Principal,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        val from = principal.name.toLong()
+        try {
+            val savedMessageDto = saveMessageService.execute(req.to, from, req.message)
+
+            stompSender.sendMessage(
+                StompMessage(savedMessageDto),
+                "${StompPathUtil.PREFIX_TOPIC_MESSAGE_HEADER}/${savedMessageDto.user1Id}-${savedMessageDto.user2Id}"
+            )
+            val messageOccurRes = MessageOccurRes(
+                savedMessageDto.user1Id,
+                savedMessageDto.user2Id,
+                UUIDUtils.getEpochMilli(savedMessageDto.messageId)
+            )
+            stompSender.sendMessageToUser(StompMessage(messageOccurRes), from)
+            stompSender.sendMessageToUser(StompMessage(messageOccurRes), req.to)
+
+        } catch (ex: RuntimeException) {
+            stompSender.sendErrorMessageToSession(
+                StompException(
+                    code = ErrorCode.BAD_REQUEST,
+                    message = ex.message.orEmpty(),
+                    path = "${StompPathUtil.PREFIX_QUEUE_USER}/${sessionId}"
+                ), sessionId
+            )
+        }
+    }
+
+    @MessageMapping("/check")
+    fun checkMessage(
+        @Payload req: CheckMessageReq,
+        principal: Principal,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        val from = principal.name.toLong()
+        try {
+            checkMessageService.execute(req.to, from, req.messageId)
+
+            val user1Id = minOf(req.to, from)
+            val user2Id = maxOf(req.to, from)
+
+            stompSender.sendMessage(
+                StompMessage(CheckMessageRes(req.messageId)),
+                "${StompPathUtil.PREFIX_TOPIC_MESSAGE_HEADER}/${user1Id}-${user2Id}"
+            )
+
+        } catch (ex: RuntimeException) {
+            stompSender.sendErrorMessageToSession(
+                StompException(
+                    code = ErrorCode.BAD_REQUEST,
+                    message = ex.message.orEmpty(),
+                    path = "${StompPathUtil.PREFIX_QUEUE_USER}/${sessionId}"
+                ), sessionId
+            )
+        }
+    }
+
+
+    @MessageMapping("/query/header")
+    fun queryHeader(
+        @Payload req: QueryHeadersReq,
+        principal: Principal,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        val userId = principal.name.toLong()
+        try {
+            val rs =
+                queryMessageService.getMessageInfosByUserId(userId, Instant.ofEpochMilli(req.epochMilli), req.limit)
+
+            stompSender.sendMessageToSession(StompMessage(rs), sessionId)
+
+        } catch (ex: RuntimeException) {
+            stompSender.sendErrorMessageToSession(
+                StompException(
+                    code = ErrorCode.BAD_REQUEST,
+                    message = ex.message.orEmpty(),
+                    path = "${StompPathUtil.PREFIX_QUEUE_USER}/${sessionId}"
+                ), sessionId
+            )
+        }
+    }
+
+    @MessageMapping("/query/message")
+    fun queryMessage(
+        @Payload req: QueryMessagesReq,
+        @Header("simpSessionId") sessionId: String
+    ) {
+        try {
+            val messageResponses = queryMessageService.getMessagesBetweenUsers(
+                req.user1Id,
+                req.user2Id,
+                Instant.ofEpochMilli(req.epochMilli),
+                req.limit,
+                req.direction
+            )
+
+            stompSender.sendMessageToSession(StompMessage(messageResponses), sessionId)
+
+        } catch (ex: RuntimeException) {
+            stompSender.sendErrorMessageToSession(
+                StompException(
+                    code = ErrorCode.BAD_REQUEST,
+                    message = ex.message.orEmpty(),
+                    path = "${StompPathUtil.PREFIX_QUEUE_USER}/${sessionId}"
+                ), sessionId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
@@ -23,4 +23,12 @@ class UserMessageInfo(
     @Column(name = "last_viewed_message_id", columnDefinition = "BINARY(16)")
     val lastViewedMessageId: UUID?
 ) {
+    fun updateLastViewedMessageId(newLastViewedMessageId: UUID?): UserMessageInfo {
+        return UserMessageInfo(
+            userMessageInfoId = this.userMessageInfoId,
+            userId = this.userId,
+            opponentUserId = this.opponentUserId,
+            lastViewedMessageId = newLastViewedMessageId
+        )
+    }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
@@ -1,0 +1,15 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.code
+
+import team.themoment.gsmNetworking.common.socket.message.MessageCode
+
+enum class MessageMessageCode : MessageCode {
+    MESSAGE,
+    MESSAGES,
+    HEADERS,
+    MESSAGE_OCCUR,
+    MESSAGE_CHECKED;
+
+    override fun code(): String {
+        return name
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
@@ -8,7 +8,7 @@ import team.themoment.gsmNetworking.domain.message.dto.api.res.MessagesRes
 import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
 
 enum class MessageMessageCode(
-    private val _supportClass: Class<out Any>
+    private val supportClass: Class<out Any>
 ) : MessageCode {
     MESSAGE(MessageDto::class.java),
     MESSAGES(MessagesRes::class.java),
@@ -16,16 +16,15 @@ enum class MessageMessageCode(
     MESSAGE_OCCUR(MessageOccurRes::class.java),
     MESSAGE_CHECKED(CheckMessageRes::class.java);
 
-    override fun code(): String {
-        return name
-    }
+    override val code: String
+        get() = name
 
     override fun isSupportClass(clazz: Class<out Any>): Boolean {
-        return this._supportClass.isAssignableFrom(clazz)
+        return this.supportClass.isAssignableFrom(clazz)
     }
 
-    override fun supportClass(): Class<out Any> {
-        return this._supportClass
+    override fun getSupportClass(): Class<out Any> {
+        return this.supportClass
     }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/code/MessageMessageCode.kt
@@ -1,15 +1,31 @@
 package team.themoment.gsmNetworking.domain.message.dto.api.code
 
 import team.themoment.gsmNetworking.common.socket.message.MessageCode
+import team.themoment.gsmNetworking.domain.message.dto.api.res.CheckMessageRes
+import team.themoment.gsmNetworking.domain.message.dto.api.res.HeadersRes
+import team.themoment.gsmNetworking.domain.message.dto.api.res.MessageOccurRes
+import team.themoment.gsmNetworking.domain.message.dto.api.res.MessagesRes
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
 
-enum class MessageMessageCode : MessageCode {
-    MESSAGE,
-    MESSAGES,
-    HEADERS,
-    MESSAGE_OCCUR,
-    MESSAGE_CHECKED;
+enum class MessageMessageCode(
+    private val _supportClass: Class<out Any>
+) : MessageCode {
+    MESSAGE(MessageDto::class.java),
+    MESSAGES(MessagesRes::class.java),
+    HEADERS(HeadersRes::class.java),
+    MESSAGE_OCCUR(MessageOccurRes::class.java),
+    MESSAGE_CHECKED(CheckMessageRes::class.java);
 
     override fun code(): String {
         return name
     }
+
+    override fun isSupportClass(clazz: Class<out Any>): Boolean {
+        return this._supportClass.isAssignableFrom(clazz)
+    }
+
+    override fun supportClass(): Class<out Any> {
+        return this._supportClass
+    }
+
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/CheckMessageReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/CheckMessageReq.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.req
+
+import java.util.UUID
+
+data class CheckMessageReq(
+    val to: Long,
+    val messageId: UUID
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryHeaderReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryHeaderReq.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.req
+
+data class QueryHeaderReq (
+    val user1Id: Long,
+    val user2Id: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryHeadersReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryHeadersReq.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.req
+
+data class QueryHeadersReq(
+    val userId: Long,
+    val epochMilli: Long,
+    val limit: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryMessagesReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/QueryMessagesReq.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.req
+
+import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
+
+data class QueryMessagesReq(
+    val user1Id: Long,
+    val user2Id: Long,
+    val epochMilli: Long,
+    val limit: Long,
+    val direction: QueryDirection
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/SaveMessageReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/SaveMessageReq.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.req
+
+data class SaveMessageReq(
+    val to: Long,
+    val message: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/CheckMessageRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/CheckMessageRes.kt
@@ -1,0 +1,10 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import java.util.UUID
+
+data class CheckMessageRes(
+    val messageId: UUID
+) {
+    val isChecked: Boolean = true
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeaderRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeaderRes.kt
@@ -3,7 +3,6 @@ package team.themoment.gsmNetworking.domain.message.dto.api.res
 import java.time.Instant
 import java.util.*
 
-//TODO 이름 적절하게 수정
 data class HeaderRes(
     val recentMessageId: UUID,
     val opponentUserId: Long,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeaderRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeaderRes.kt
@@ -1,0 +1,12 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+import java.time.Instant
+import java.util.*
+
+//TODO 이름 적절하게 수정
+data class HeaderRes(
+    val recentMessageId: UUID,
+    val opponentUserId: Long,
+    val recentMessageTime: Instant,
+    val isChecked: Boolean
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeadersRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/HeadersRes.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+
+data class HeadersRes(
+    val contents: List<HeaderRes>
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessageOccurRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessageOccurRes.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+data class MessageOccurRes(
+    val user1Id: Long,
+    val user2Id: Long,
+    val messageTime: Long,
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessageRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessageRes.kt
@@ -1,0 +1,15 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import java.util.UUID
+
+data class MessageRes(
+    val messageId: UUID,
+    val user1Id: Long,
+    val user2Id: Long,
+    val direction: Message.MessageDirection,
+    val content: String,
+    val messageTime: Long,
+    val isCheckedUser1: Boolean,
+    val isCheckedUser2: Boolean,
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessagesRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/MessagesRes.kt
@@ -1,0 +1,5 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+data class MessagesRes(
+    val contents: List<MessageRes>
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/SaveMessageRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/SaveMessageRes.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.dto.api.res
+
+data class SaveMessageRes(
+    val to: Long,
+    val message: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/HeaderDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/HeaderDto.kt
@@ -1,0 +1,11 @@
+package team.themoment.gsmNetworking.domain.message.dto.domain
+
+import java.util.*
+
+
+data class HeaderDto(
+    val headerId: Long,
+    val user1Id: Long,
+    val user2Id: Long,
+    val recentMessageId: UUID
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageRepository.kt
@@ -2,8 +2,9 @@ package team.themoment.gsmNetworking.domain.message.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.themoment.gsmNetworking.domain.message.domain.Message
+import java.util.*
 
 
-interface MessageRepository : CrudRepository<Message, Long>, MessageCustomRepository {
+interface MessageRepository : CrudRepository<Message, UUID>, MessageCustomRepository {
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
@@ -7,4 +7,6 @@ import team.themoment.gsmNetworking.domain.message.domain.UserMessageInfo
 interface UserMessageInfoRepository : CrudRepository<UserMessageInfo, Long> {
     fun findByUserId(userId: Long): UserMessageInfo?
 
+    fun findByUserIdAndOpponentUserId(userId: Long, opponentUserId: Long): UserMessageInfo?
+
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/CheckMessageService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/CheckMessageService.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.message.service
+
+import java.util.UUID
+
+interface CheckMessageService {
+    fun execute(toUserId: Long, fromUserId: Long, messageId: UUID)
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/QueryMessageService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/QueryMessageService.kt
@@ -1,0 +1,23 @@
+package team.themoment.gsmNetworking.domain.message.service
+
+import team.themoment.gsmNetworking.domain.message.dto.domain.HeaderDto
+import team.themoment.gsmNetworking.domain.message.dto.api.res.HeaderRes
+import team.themoment.gsmNetworking.domain.message.dto.api.res.MessageRes
+import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
+import java.time.Instant
+
+interface QueryMessageService {
+
+    fun getHeaderByUserIds(user1Id: Long, user2Id: Long): HeaderDto?
+
+    fun getMessageInfosByUserId(userId: Long, time: Instant, limit: Long): List<HeaderRes>
+
+    fun getMessagesBetweenUsers(
+        user1Id: Long,
+        user2Id: Long,
+        time: Instant,
+        limit: Long,
+        direction: QueryDirection
+    ): List<MessageRes>
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/SaveMessageService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/SaveMessageService.kt
@@ -1,0 +1,7 @@
+package team.themoment.gsmNetworking.domain.message.service
+
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
+
+interface SaveMessageService {
+    fun execute(toUserId: Long, fromUserId: Long, message: String): MessageDto
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
@@ -1,0 +1,39 @@
+package team.themoment.gsmNetworking.domain.message.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import team.themoment.gsmNetworking.domain.message.repository.MessageRepository
+import team.themoment.gsmNetworking.domain.message.repository.UserMessageInfoRepository
+import team.themoment.gsmNetworking.domain.message.service.CheckMessageService
+import java.util.*
+
+@Service
+class CheckMessageServiceImpl(
+    private val messageRepository: MessageRepository,
+    private val userMessageInfoRepository: UserMessageInfoRepository,
+) : CheckMessageService {
+
+    @Transactional
+    override fun execute(toUserId: Long, fromUserId: Long, messageId: UUID) {
+        val message = messageRepository.findById(messageId)
+            .orElseThrow { IllegalArgumentException("유효하지 않은 MessageId. MessageId가 $messageId 인 Message를 찾을 수 없습니다.") }
+
+        if (!validMessageByUserIds(toUserId, fromUserId, message)) {
+            throw IllegalArgumentException("유효하지 않은 MessageId. $fromUserId 와 $toUserId 사이의 메시지가 아닙니다.")
+        }
+
+        val fromUserMessageInfo = userMessageInfoRepository.findByUserIdAndOpponentUserId(fromUserId, toUserId)
+            ?: throw IllegalArgumentException("유효하지 않은 UserId. $fromUserId 와 $toUserId 사이의 메시지를 찾을 수 없습니다.")
+
+        userMessageInfoRepository.save(
+            fromUserMessageInfo.updateLastViewedMessageId(messageId)
+        )
+    }
+
+    private fun validMessageByUserIds(toUserId: Long, fromUserId: Long, message: Message): Boolean {
+        val user1Id = minOf(toUserId, fromUserId)
+        val user2Id = maxOf(toUserId, fromUserId)
+        return user1Id == message.user1Id && user2Id == message.user2Id
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/QueryMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/QueryMessageServiceImpl.kt
@@ -1,0 +1,105 @@
+package team.themoment.gsmNetworking.domain.message.service.impl
+
+import com.fasterxml.uuid.UUIDComparator
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import team.themoment.gsmNetworking.domain.message.dto.domain.HeaderDto
+import team.themoment.gsmNetworking.domain.message.dto.api.res.HeaderRes
+import team.themoment.gsmNetworking.domain.message.dto.api.res.MessageRes
+import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
+import team.themoment.gsmNetworking.domain.message.repository.MessageRepository
+import team.themoment.gsmNetworking.domain.message.repository.UserMessageInfoRepository
+import team.themoment.gsmNetworking.domain.message.service.QueryMessageService
+import team.themoment.gsmNetworking.domain.user.repository.UserRepository
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class QueryMessageServiceImpl(
+    private val messageRepository: MessageRepository,
+    private val userMessageInfoRepository: UserMessageInfoRepository,
+    private val userRepository: UserRepository
+) : QueryMessageService {
+
+    @Transactional(readOnly = true)
+    override fun getHeaderByUserIds(user1Id: Long, user2Id: Long): HeaderDto? {
+        val (user1Id, user2Id) = if (user1Id < user2Id) user1Id to user2Id else user2Id to user1Id
+        if (!userRepository.existsById(user1Id)) {
+            throw IllegalArgumentException("사용자 ID가 $user1Id 인 사용자를 찾을 수 없습니다")
+        }
+        if (!userRepository.existsById(user2Id)) {
+            throw IllegalArgumentException("사용자 ID가 $user2Id 인 사용자를 찾을 수 없습니다")
+        }
+        return messageRepository.findHeaderBetweenUsers(user1Id, user2Id)
+            ?.let { HeaderDto(it.headerId, it.user1Id, it.user2Id, it.recentMessageId) }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getMessageInfosByUserId(userId: Long, time: Instant, limit: Long): List<HeaderRes> {
+        if (!userRepository.existsById(userId)) {
+            throw IllegalArgumentException("사용자 ID가 $userId 인 사용자를 찾을 수 없습니다")
+        }
+
+        val messageMetaDtos = messageRepository.findMessageInfosByUserId(userId, time, limit)
+
+        return messageMetaDtos.map {
+            val opponentUserId = findOtherUserId(userId, it.user1Id, it.user2Id)
+
+            HeaderRes(
+                it.recentMessageId,
+                opponentUserId,
+                UUIDUtils.getInstant(it.recentMessageId),
+                isAllCheckedMessage(it.recentMessageId, it.lastViewedChatId)
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getMessagesBetweenUsers(
+        user1Id: Long,
+        user2Id: Long,
+        time: Instant,
+        limit: Long,
+        direction: QueryDirection
+    ): List<MessageRes> {
+        val (user1Id, user2Id) = if (user1Id < user2Id) user1Id to user2Id else user2Id to user1Id //TODO 그냥 invalid 예외 던지는게 더 나을듯
+
+        val user1MessageInfo = userMessageInfoRepository.findByUserId(user1Id)
+            ?: throw IllegalArgumentException("사용자 ID가 $user1Id 인 사용자를 찾을 수 없습니다")
+        val user2MessageInfo = userMessageInfoRepository.findByUserId(user2Id)
+            ?: throw IllegalArgumentException("사용자 ID가 $user2Id 인 사용자를 찾을 수 없습니다")
+
+        return messageRepository.findMessagesBetweenUsers(user1Id, user2Id, time, limit, direction).map {
+            MessageRes(
+                messageId = it.messageId,
+                user1Id = it.user1Id,
+                user2Id = it.user2Id,
+                direction = it.direction,
+                content = it.content,
+                messageTime = UUIDUtils.getEpochMilli(it.messageId),
+                isCheckedUser1 = isCheckedMessage(user1MessageInfo.lastViewedMessageId, it.messageId),
+                isCheckedUser2 = isCheckedMessage(user2MessageInfo.lastViewedMessageId, it.messageId)
+            )
+        }
+    }
+
+
+    private fun isAllCheckedMessage(recentMessageId: UUID, lastViewedChatId: UUID?): Boolean =
+        if (lastViewedChatId == null) false else recentMessageId <= lastViewedChatId
+
+    private fun findOtherUserId(myUserId: Long, userId1: Long, userId2: Long): Long =
+        when (myUserId) {
+            userId1 -> userId2
+            userId2 -> userId1
+            else -> throw RuntimeException("내 아이디($myUserId)가 아이디1($userId1)과 아이디2($userId2) 중 어느 것과도 일치하지 않습니다.")
+        }
+
+    private fun isCheckedMessage(lastViewedMessageId: UUID?, messageId: UUID): Boolean {
+        return if (lastViewedMessageId == null) {
+            false
+        } else {
+            UUIDComparator.staticCompare(lastViewedMessageId, messageId) != 1
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
@@ -1,0 +1,122 @@
+package team.themoment.gsmNetworking.domain.message.service.impl
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.util.UUIDUtils
+import team.themoment.gsmNetworking.domain.message.domain.Header
+import team.themoment.gsmNetworking.domain.message.domain.Message
+import team.themoment.gsmNetworking.domain.message.domain.UserMessageInfo
+import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
+import team.themoment.gsmNetworking.domain.message.repository.HeaderRepository
+import team.themoment.gsmNetworking.domain.message.repository.MessageRepository
+import team.themoment.gsmNetworking.domain.message.repository.UserMessageInfoRepository
+import team.themoment.gsmNetworking.domain.message.service.SaveMessageService
+import java.util.UUID
+
+@Service
+class SaveMessageServiceImpl(
+    private val messageRepository: MessageRepository,
+    private val userMessageInfoRepository: UserMessageInfoRepository,
+    private val headerRepository: HeaderRepository
+) : SaveMessageService {
+
+    @Transactional
+    override fun execute(toUserId: Long, fromUserId: Long, message: String): MessageDto {
+        val (user1Id, user2Id) = if (fromUserId < toUserId) fromUserId to toUserId else toUserId to fromUserId // TODO 로직 중복
+
+        val direction =
+            if (user1Id == fromUserId) Message.MessageDirection.ToUser1 else Message.MessageDirection.ToUser2
+
+        val header = messageRepository.findHeaderBetweenUsers(user1Id, user2Id)
+        val newMessageId = UUIDUtils.generateUUIDv7()
+
+        if (header != null) {
+            val savedMessage = saveMessage(newMessageId, header, direction, message)
+
+            // 메시지를 보내는 사람은 메시지를 본 대상으로 판단
+            val userMessageInfo = userMessageInfoRepository.findByUserId(fromUserId)
+                ?: throw IllegalArgumentException("userId가 ${fromUserId}인 사용자를 찾을 수 없습니다")
+            userMessageInfoRepository.save(
+                UserMessageInfo(
+                    userMessageInfo.userMessageInfoId,
+                    userMessageInfo.userId,
+                    userMessageInfo.opponentUserId,
+                    newMessageId
+                )
+            )
+
+            return MessageDto(
+                savedMessage.messageId,
+                savedMessage.user1Id,
+                savedMessage.user2Id,
+                savedMessage.direction,
+                savedMessage.content
+            )
+        } else {
+            val savedMessage = saveNewMessage(newMessageId, user1Id, user2Id, direction, message)
+
+            // 새로운 Header, UserMessageInfo 생성
+            // 메시지를 보내는 사람은 메시지를 본 대상으로 판단
+            userMessageInfoRepository.save(
+                UserMessageInfo(
+                    userId = fromUserId,
+                    opponentUserId = toUserId,
+                    lastViewedMessageId = newMessageId
+                )
+            )
+
+            // 다른 사용자의 새로운 Header, UserMessageInfo 생성
+            userMessageInfoRepository.save(
+                UserMessageInfo(
+                    userId = toUserId,
+                    opponentUserId = fromUserId,
+                    lastViewedMessageId = null
+                )
+            )
+
+            return MessageDto(
+                savedMessage.messageId,
+                savedMessage.user1Id,
+                savedMessage.user2Id,
+                savedMessage.direction,
+                savedMessage.content
+            )
+        }
+
+    }
+
+    private fun saveMessage(
+        newMessageId: UUID,
+        header: Header,
+        direction: Message.MessageDirection,
+        content: String
+    ): Message {
+        val refreshedHeader = header.copyWithNewRecentChatId(header, newMessageId)
+        val newMessage = Message(
+            messageId = newMessageId,
+            header = refreshedHeader,
+            direction = direction,
+            content = content
+        )
+        headerRepository.save(refreshedHeader)
+        return messageRepository.save(newMessage)
+    }
+
+    private fun saveNewMessage(
+        newMessageId: UUID,
+        user1Id: Long,
+        user2Id: Long,
+        direction: Message.MessageDirection,
+        content: String
+    ): Message {
+        val newHeader = Header(user1Id, user2Id, newMessageId)
+        val newMessage = Message(
+            messageId = newMessageId,
+            header = newHeader,
+            direction = direction,
+            content = content
+        )
+        headerRepository.save(newHeader)
+        return messageRepository.save(newMessage)
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
@@ -124,5 +124,5 @@ class SaveMessageServiceImpl(
     }
 
     private fun getUser1IdAndUser2Id(toUserId: Long, fromUserId: Long): Pair<Long, Long> =
-        if (fromUserId < toUserId) fromUserId to toUserId else toUserId to fromUserId
+        if (fromUserId < toUserId) fromUserId to toUserId else toUserId to fromUserId //TODO 서비스 단에서는 user1Id, user2Id, direction로 판단하도록 변경. API 단에서 필터링
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/exception/handler/GlobalSocketExceptionHandler.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/exception/handler/GlobalSocketExceptionHandler.kt
@@ -7,6 +7,7 @@ import team.themoment.gsmNetworking.common.exception.StompException
 import team.themoment.gsmNetworking.common.socket.sender.StompSender
 
 
+// TODO 이거 지금 딱히 사용 안되는데 지우고 나중에 필요할 떄 다시 구현하기
 @RestControllerAdvice
 class GlobalSocketExceptionHandler(
     private val stompSender: StompSender


### PR DESCRIPTION
## 개요 
채팅 API 및 비즈니스 로직을 구현하였습니다.
그 외 오류 수정과 Repository 메서드 추가 작업을 진행하였습니다.

## 본문

#### 채팅 관련 서비스 객체 구현
- `SaveMessageService` : 채팅을 저장하고 채팅 관련 사용자 정보를 갱신합니다.
- `CheckMessageService` : 사용자가 특정 채팅을 확인한 상태로 변경합니다.
- `QueryMessageService` : 채팅과 관련된 객체를 가져옵니다.

#### 채팅 관련 API 구현
- `MessageHttpController` : HTTP 요청을 매핑하는 Controller 입니다.
- `MessageWebsocketController` : Websocket(STOMP) 요청을 매핑하는 Controller 입니다.

#### API, 비즈니스 로직 구현에 필요한 DTO 구현

#### MessageRepository ID 타입이 Long으로 잘못 지정된 문제 해결
UUID로 알맞게 변경하였습니다.

#### `UserMessageInfoRepository#findByUserIdAndOpponentUserId` 메서드 구현
비즈니스 로직 구현에 필요하여 추가하였습니다.