### PR TITLE
임시멘토를 firebaseId 대신 realId로 식별

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/TempMentorController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/controller/TempMentorController.kt
@@ -26,9 +26,9 @@ class TempMentorController(
         return ResponseEntity.ok(tempMentorList)
     }
 
-    @GetMapping("/{firebaseId}")
-    fun findTempMentor(@PathVariable firebaseId: String): ResponseEntity<TempMentorInfoDto> {
-        val tempMentor = queryTempMentorService.execute(firebaseId)
+    @GetMapping("/{id}")
+    fun findTempMentor(@PathVariable id: Long): ResponseEntity<TempMentorInfoDto> {
+        val tempMentor = queryTempMentorService.execute(id)
         return ResponseEntity.ok(tempMentor)
     }
 
@@ -38,9 +38,9 @@ class TempMentorController(
         return ResponseEntity.ok(searchTempMentorList)
     }
 
-    @DeleteMapping("/{firebaseId}")
-    fun deleteTempMentor(@PathVariable firebaseId: String): ResponseEntity<Void> {
-        deleteTempMentorService.execute(firebaseId)
+    @DeleteMapping("/{id}")
+    fun deleteTempMentor(@PathVariable id: Long): ResponseEntity<Void> {
+        deleteTempMentorService.execute(id)
         return ResponseEntity.status(HttpStatus.RESET_CONTENT).build()
     }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class SearchTempMentorInfoDto(
     val id: Long,
-    val firebaseId: String,
     val name: String,
     val email: String?,
     val generation: Int,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class TempMentorInfoDto(
     var id: Long,
-    val firebaseId: String,
     val name: String,
     val email: String,
     val generation: Int,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/TempMentorRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/TempMentorRepository.kt
@@ -10,6 +10,4 @@ interface TempMentorRepository : CrudRepository<TempMentor, Long> {
 
     fun findByName(name: String): List<TempMentor>
 
-    fun findByFirebaseId(firebaseId: String): TempMentor?
-
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteTempMentorService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/DeleteTempMentorService.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.domain.mentor.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -20,9 +21,9 @@ class DeleteTempMentorService(
      *
      * @param firebaseId 임시멘토의 식별자
      */
-    fun execute(firebaseId: String) {
-        val tempMentor = tempMentorRepository.findByFirebaseId(firebaseId)
-            ?: throw ExpectedException("존재하지 않는 firebaseId : $firebaseId 입니다.", HttpStatus.NOT_FOUND)
+    fun execute(id: Long) {
+        val tempMentor = tempMentorRepository.findByIdOrNull(id)
+            ?: throw ExpectedException("존재하지 않는 id 입니다.", HttpStatus.NOT_FOUND)
         tempMentor.deleted = true
     }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorListService.kt
@@ -24,7 +24,6 @@ class QueryTempMentorListService(
         val tempMentors = tempMentorRepository.findAll().map { tempMentor ->
             TempMentorInfoDto(
                 tempMentor.id,
-                tempMentor.firebaseId,
                 tempMentor.name,
                 tempMentor.email ?: "",
                 tempMentor.generation,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryTempMentorService.kt
@@ -1,5 +1,6 @@
 package team.themoment.gsmNetworking.domain.mentor.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -23,13 +24,12 @@ class QueryTempMentorService(
      * @param firebaseId 임시멘토의 식별자
      * @return 특정 임시멘토의 정보를 담은 dto
      */
-    fun execute(firebaseId: String): TempMentorInfoDto {
-        val tempMentor = tempMentorRepository.findByFirebaseId(firebaseId)
-            ?: throw ExpectedException("존재하지 않는 firebaseId : $firebaseId 입니다.", HttpStatus.NOT_FOUND)
+    fun execute(id: Long): TempMentorInfoDto {
+        val tempMentor = tempMentorRepository.findByIdOrNull(id)
+            ?: throw ExpectedException("존재하지 않는 id 입니다.", HttpStatus.NOT_FOUND)
 
         return TempMentorInfoDto(
             tempMentor.id,
-            tempMentor.firebaseId,
             tempMentor.name,
             tempMentor.email ?: "",
             tempMentor.generation,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/SearchTempMentorListService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/SearchTempMentorListService.kt
@@ -25,7 +25,6 @@ class QueryTempMentorListByNameService(
         val searchTempMentors = tempMentorRepository.findByName(name).map { tempMentor ->
             SearchTempMentorInfoDto(
                 tempMentor.id,
-                tempMentor.firebaseId,
                 tempMentor.name,
                 tempMentor.email,
                 tempMentor.generation,

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsServiceTest.kt
@@ -87,7 +87,6 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
     val dummyTempMentorInfoDtos = listOf(
         TempMentorInfoDto(
             id = 10L,
-            firebaseId = "firebase_1",
             name = "임꺽정",
             email = "lim@gmail.com",
             generation = 3,
@@ -100,7 +99,6 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         ),
         TempMentorInfoDto(
             id = 11L,
-            firebaseId = "firebase_2",
             name = "유관순",
             email = "you@gmail.com",
             generation = 5,
@@ -113,7 +111,6 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         ),
         TempMentorInfoDto(
             id = 12L,
-            firebaseId = "firebase_3",
             name = "정도전",
             email = "jeong@gmail.com",
             generation = 3,
@@ -126,7 +123,6 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
         ),
         TempMentorInfoDto(
             id = 13L,
-            firebaseId = "firebase_4",
             name = "김유신",
             email = "kim@gmail.com",
             generation = 2,
@@ -156,7 +152,6 @@ class QueryAllMentorsServiceTest : BehaviorSpec({
 
     val sameUserTempMentor = TempMentorInfoDto(
         id = 14L,
-        firebaseId = "firebase_5",
         name = "홍길동",
         email = "hong@gmail.com",
         generation = 3,


### PR DESCRIPTION
## 개요

firebaseId로 식별하던 api를 realId로 식별

## 본문

firebase의존성을 제거한 이상 firebaseId가 필요가 없다고 하셔서 search/{name} api에서 받은 realId로 요청을 할거라고 하셨습니다.

## 피드백
임시멘토 테이블 컬럼에서 firebaseId를 제거하고 임시멘토 더미데이터 다시 삽입하는거에 대해서 어떻게 생각하시나요?