### PR TITLE
채팅 check API 개선

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/message/GlobalMessageCode.kt
@@ -1,9 +1,11 @@
 package team.themoment.gsmNetworking.common.socket.message
 
+import team.themoment.gsmNetworking.common.socket.model.StompErrorResponse
+
 enum class GlobalMessageCode(
     private val supportClass: Class<out Any>
 ) : MessageCode {
-    ERROR(StompMessage::class.java);
+    ERROR(StompErrorResponse::class.java);
 
     override val code: String
         get() = name

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/controller/MessageWebsocketController.kt
@@ -67,13 +67,13 @@ class MessageWebsocketController(
     ) {
         val from = principal.name.toLong()
         try {
-            checkMessageService.execute(req.to, from, req.messageId)
+            checkMessageService.execute(req.to, from, Instant.ofEpochMilli(req.epochMilli))
 
             val user1Id = minOf(req.to, from)
             val user2Id = maxOf(req.to, from)
 
             stompSender.sendMessage(
-                StompMessage(CheckMessageRes(req.messageId), MessageMessageCode.MESSAGE_CHECKED),
+                StompMessage(CheckMessageRes(from, req.epochMilli), MessageMessageCode.MESSAGE_CHECKED),
                 "${StompPathUtil.PREFIX_TOPIC_MESSAGE_HEADER}/${user1Id}-${user2Id}"
             )
 
@@ -100,7 +100,10 @@ class MessageWebsocketController(
             val headerResponses =
                 queryMessageService.getMessageInfosByUserId(userId, Instant.ofEpochMilli(req.epochMilli), req.limit)
 
-            stompSender.sendMessageToSession(StompMessage(HeadersRes(headerResponses), MessageMessageCode.HEADERS), sessionId)
+            stompSender.sendMessageToSession(
+                StompMessage(HeadersRes(headerResponses), MessageMessageCode.HEADERS),
+                sessionId
+            )
 
         } catch (ex: RuntimeException) {
             stompSender.sendErrorMessageToSession(
@@ -127,7 +130,10 @@ class MessageWebsocketController(
                 req.direction
             )
 
-            stompSender.sendMessageToSession(StompMessage(MessagesRes(messageResponses), MessageMessageCode.MESSAGES), sessionId)
+            stompSender.sendMessageToSession(
+                StompMessage(MessagesRes(messageResponses), MessageMessageCode.MESSAGES),
+                sessionId
+            )
 
         } catch (ex: RuntimeException) {
             stompSender.sendErrorMessageToSession(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
@@ -1,6 +1,5 @@
 package team.themoment.gsmNetworking.domain.message.domain
 
-import java.util.UUID
 import javax.persistence.*
 
 @Entity
@@ -19,16 +18,15 @@ class UserMessageInfo(
     @Column(name = "opponent_user_id", nullable = false)
     val opponentUserId: Long,
 
-    // 생성되었지만, 특정 사용자외의 메시지를 한번도 확인하지 않은 경우 null 상태를 가짐
-    @Column(name = "last_viewed_message_id", columnDefinition = "BINARY(16)")
-    val lastViewedMessageId: UUID?
+    @Column(name = "last_viewed_time")
+    val lastViewedEpochMilli: Long = 0
 ) {
-    fun updateLastViewedMessageId(newLastViewedMessageId: UUID?): UserMessageInfo {
+    fun updateLastViewedEpochMilli(newLastViewedEpochMilli: Long): UserMessageInfo {
         return UserMessageInfo(
             userMessageInfoId = this.userMessageInfoId,
             userId = this.userId,
             opponentUserId = this.opponentUserId,
-            lastViewedMessageId = newLastViewedMessageId
+            lastViewedEpochMilli = newLastViewedEpochMilli
         )
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/CheckMessageReq.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/req/CheckMessageReq.kt
@@ -1,8 +1,6 @@
 package team.themoment.gsmNetworking.domain.message.dto.api.req
 
-import java.util.UUID
-
 data class CheckMessageReq(
     val to: Long,
-    val messageId: UUID
+    val epochMilli: Long
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/CheckMessageRes.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/api/res/CheckMessageRes.kt
@@ -1,10 +1,6 @@
 package team.themoment.gsmNetworking.domain.message.dto.api.res
 
-import team.themoment.gsmNetworking.domain.message.domain.Message
-import java.util.UUID
-
 data class CheckMessageRes(
-    val messageId: UUID
-) {
-    val isChecked: Boolean = true
-}
+    val userId: Long,
+    val checkedEpochMilli: Long
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepositoryImpl.kt
@@ -26,7 +26,7 @@ class MessageCustomRepositoryImpl(
                     header.user2Id,
                     message.direction,
                     header.recentMessageId,
-                    userMessageInfo.lastViewedMessageId
+                    userMessageInfo.lastViewedEpochMilli
                 )
             )
             .from(header)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/CheckMessageService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/CheckMessageService.kt
@@ -1,7 +1,7 @@
 package team.themoment.gsmNetworking.domain.message.service
 
-import java.util.UUID
+import java.time.Instant
 
 interface CheckMessageService {
-    fun execute(toUserId: Long, fromUserId: Long, messageId: UUID)
+    fun execute(toUserId: Long, fromUserId: Long, time: Instant)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
@@ -1,52 +1,26 @@
 package team.themoment.gsmNetworking.domain.message.service.impl
 
-import com.fasterxml.uuid.UUIDComparator
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.themoment.gsmNetworking.domain.message.domain.Message
-import team.themoment.gsmNetworking.domain.message.repository.MessageRepository
 import team.themoment.gsmNetworking.domain.message.repository.UserMessageInfoRepository
 import team.themoment.gsmNetworking.domain.message.service.CheckMessageService
-import java.util.*
+import java.time.Instant
 
 @Service
 class CheckMessageServiceImpl(
-    private val messageRepository: MessageRepository,
     private val userMessageInfoRepository: UserMessageInfoRepository,
 ) : CheckMessageService {
 
     @Transactional
-    override fun execute(toUserId: Long, fromUserId: Long, messageId: UUID) {
-        val message = messageRepository.findById(messageId)
-            .orElseThrow { IllegalArgumentException("유효하지 않은 MessageId. MessageId가 $messageId 인 Message를 찾을 수 없습니다.") }
-
-        if (!validMessageByUserIds(toUserId, fromUserId, message)) {
-            throw IllegalArgumentException("유효하지 않은 MessageId. $fromUserId 와 $toUserId 사이의 메시지가 아닙니다.")
-        }
+    override fun execute(toUserId: Long, fromUserId: Long, time: Instant) {
 
         val fromUserMessageInfo = userMessageInfoRepository.findByUserIdAndOpponentUserId(fromUserId, toUserId)
             ?: throw IllegalArgumentException("유효하지 않은 UserId. $fromUserId 와 $toUserId 사이의 메시지를 찾을 수 없습니다.")
 
-        if (isEarlyMessage(fromUserMessageInfo.lastViewedMessageId, messageId)) {
-            userMessageInfoRepository.save(
-                fromUserMessageInfo.updateLastViewedMessageId(messageId)
-            )
+        if (time.toEpochMilli() > fromUserMessageInfo.lastViewedEpochMilli) {
+            userMessageInfoRepository.save(fromUserMessageInfo.updateLastViewedEpochMilli(time.toEpochMilli()))
         } else {
-            // TODO 사용자가 요청한 messageId가 이미 읽은 ID인 경우
-        }
-    }
-
-    private fun validMessageByUserIds(toUserId: Long, fromUserId: Long, message: Message): Boolean {
-        val user1Id = minOf(toUserId, fromUserId)
-        val user2Id = maxOf(toUserId, fromUserId)
-        return user1Id == message.user1Id && user2Id == message.user2Id
-    }
-
-    private fun isEarlyMessage(lastViewedMessageId: UUID?, messageId: UUID): Boolean {
-        return if (lastViewedMessageId == null) {
-            false
-        } else {
-            UUIDComparator.staticCompare(lastViewedMessageId, messageId) != 0
+            //TODO 새로 체크 요청한 시간이 기존에 체크 요청한 시간보다 큰 경우 처리
         }
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
@@ -22,36 +22,32 @@ class SaveMessageServiceImpl(
 
     @Transactional
     override fun execute(toUserId: Long, fromUserId: Long, message: String): MessageDto {
-        val (user1Id, user2Id) = getUser1IdAndUser2Id(toUserId, fromUserId)
+        val (user1Id, user2Id) = if (fromUserId < toUserId) fromUserId to toUserId else toUserId to fromUserId
+
+        val direction =
+            if (user1Id == fromUserId) Message.MessageDirection.ToUser1 else Message.MessageDirection.ToUser2
 
         val header = messageRepository.findHeaderBetweenUsers(user1Id, user2Id)
 
-        val savedMessage = saveMessage(toUserId, fromUserId, header, message)
+        val newMessageId = UUIDUtils.generateUUIDv7()
+
+        val savedMessage = if (header != null) {
+            saveMessage(newMessageId, header, direction, message)
+        } else {
+            saveFirstMessage(newMessageId, user1Id, user2Id, direction, message)
+        }
 
         return createMessageDto(savedMessage)
     }
 
-    private fun updateUserMessageInfo(userId: Long, opponentUserId: Long, newMessageId: UUID?) {
-        val userMessageInfo = userMessageInfoRepository.findByUserIdAndOpponentUserId(userId, opponentUserId)
-            ?: throw IllegalArgumentException("유효하지 않은 UserId. $userId 와 $opponentUserId 사이의 메시지를 찾을 수 없습니다.")
-
-        val updatedInfo = UserMessageInfo(
-            userMessageInfo.userMessageInfoId,
-            userMessageInfo.userId,
-            userMessageInfo.opponentUserId,
-            newMessageId ?: userMessageInfo.lastViewedMessageId
-        )
-
-        userMessageInfoRepository.save(updatedInfo)
-    }
-
+    // 기존에 채팅이 존재함, header를 갱신하고, 새로운 message를 저장함
     private fun saveMessage(
         newMessageId: UUID,
         header: Header,
         direction: Message.MessageDirection,
         content: String
     ): Message {
-        val refreshedHeader = updateHeader(header, newMessageId)
+        val refreshedHeader = headerRepository.save(header.copyWithNewRecentChatId(header, newMessageId))
         val newMessage = Message(
             messageId = newMessageId,
             header = refreshedHeader,
@@ -61,6 +57,7 @@ class SaveMessageServiceImpl(
         return messageRepository.save(newMessage)
     }
 
+    // 채팅이 처음 시작됨, header, userMessageInfo가 message와 함께 생성됨
     private fun saveFirstMessage(
         newMessageId: UUID,
         user1Id: Long,
@@ -68,20 +65,18 @@ class SaveMessageServiceImpl(
         direction: Message.MessageDirection,
         content: String
     ): Message {
-        val newHeader = Header(user1Id, user2Id, newMessageId)
+        val newHeader = headerRepository.save(Header(user1Id, user2Id, newMessageId))
         val newMessage = Message(
             messageId = newMessageId,
-            header = updateHeader(newHeader, newMessageId),
+            header = newHeader,
             direction = direction,
             content = content
         )
-        return messageRepository.save(newMessage)
-    }
+        // 둘 다 상대방의 채팅을 아직 확인하지 않았으므로 기본값이 부여됨
+        userMessageInfoRepository.save(UserMessageInfo(userId = user1Id, opponentUserId = user2Id))
+        userMessageInfoRepository.save(UserMessageInfo(userId = user2Id, opponentUserId = user1Id))
 
-    private fun updateHeader(header: Header, newMessageId: UUID): Header {
-        val refreshedHeader = header.copyWithNewRecentChatId(header, newMessageId)
-        headerRepository.save(refreshedHeader)
-        return refreshedHeader
+        return messageRepository.save(newMessage)
     }
 
     private fun createMessageDto(savedMessage: Message): MessageDto {
@@ -93,36 +88,4 @@ class SaveMessageServiceImpl(
             savedMessage.content
         )
     }
-
-    private fun saveMessage(
-        fromUserId: Long,
-        toUserId: Long,
-        header: Header?,
-        message: String
-    ): Message {
-        val (user1Id, user2Id) = getUser1IdAndUser2Id(toUserId, fromUserId)
-
-        val direction =
-            if (user1Id == fromUserId) Message.MessageDirection.ToUser1 else Message.MessageDirection.ToUser2
-
-        val newMessageId = UUIDUtils.generateUUIDv7()
-
-        if (header != null) {
-            val savedMessage = saveMessage(newMessageId, header, direction, message)
-
-            updateUserMessageInfo(userId = fromUserId, opponentUserId = toUserId, newMessageId = newMessageId)
-
-            return savedMessage
-        } else {
-            val savedMessage = saveFirstMessage(newMessageId, user1Id, user2Id, direction, message)
-
-            updateUserMessageInfo(userId = fromUserId, opponentUserId = toUserId, newMessageId = newMessageId)
-            updateUserMessageInfo(userId = toUserId, opponentUserId = fromUserId, newMessageId = null)
-
-            return savedMessage
-        }
-    }
-
-    private fun getUser1IdAndUser2Id(toUserId: Long, fromUserId: Long): Pair<Long, Long> =
-        if (fromUserId < toUserId) fromUserId to toUserId else toUserId to fromUserId //TODO 서비스 단에서는 user1Id, user2Id, direction로 판단하도록 변경. API 단에서 필터링
 }


### PR DESCRIPTION
## 개요
채팅 check API 개선 작업을 수행했습니다.

## 작업
### 1. Enum `GlobalMessageCode.ERROR`의 필드 `supportClass` 버그 수정
`supportClass`가 `StompMessage`에서 `StompErrorResponse`로 올바르게 변경되었습니다.

### 2. 채팅 check API에서 messageId 대신 시간 사용으로 변경
#### 변경 이유

- messageId를 참조할 때 서비스 결합도가 높아지는 문제가 있었습니다.
- 확인한 messageId가 삭제된 경우, 근처의 메시지를 확인하여 재할당해주는 로직이 필요했습니다.
- Message와 `UserMessageInfo` 간의 결합도가 높아졌습니다 (messageId의 유효성 확인 필요).
- messageId를 참조할 정도로 정확한 처리가 필요하지 않았습니다 (차이가 나더라도 millisec 단위).

#### 변경 사항
- `UserMessageInfo` 엔티티 필드를 messageId(UUID)에서 unix time(Long)으로 수정했습니다.
- 필드 변경 사항에 맞게 서비스 객체, DTO, Controller도 수정했습니다.