### PR TITLE
User 엔티티의 profileUrl 등록 로직 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/controller/UserController.kt
@@ -1,0 +1,25 @@
+package team.themoment.gsmNetworking.domain.user.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
+import team.themoment.gsmNetworking.domain.user.service.ProfileUrlRegistrationService
+
+@RestController
+@RequestMapping("/api/v1/user")
+class UserController(
+    private val authenticatedUserManager: AuthenticatedUserManager,
+    private val profileUrlRegistrationService: ProfileUrlRegistrationService
+) {
+
+    @PostMapping("/profile/{profileUrl}")
+    fun profileUrlRegistration(@PathVariable profileUrl: String): ResponseEntity<Void> {
+        val authenticationId = authenticatedUserManager.getName()
+        profileUrlRegistrationService.execute(authenticationId, profileUrl)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
@@ -1,0 +1,37 @@
+package team.themoment.gsmNetworking.domain.user.service
+
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.common.exception.ExpectedException
+import team.themoment.gsmNetworking.domain.user.domain.User
+import team.themoment.gsmNetworking.domain.user.repository.UserRepository
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class ProfileUrlRegistrationService(
+    private val userRepository: UserRepository
+) {
+
+    fun execute(authenticationId: Long, profileUrl: String) {
+        val user = userRepository.findByAuthenticationId(authenticationId)
+            ?: throw ExpectedException("user를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+
+        profileUrlRegistration(user, profileUrl)
+    }
+
+    fun profileUrlRegistration(user: User, profileUrl: String) {
+        val addProfileUrlToUser = User(
+            user.userId,
+            user.authenticationId,
+            user.name,
+            user.generation,
+            user.email,
+            user.phoneNumber,
+            user.snsUrl,
+            profileUrl
+        )
+
+        userRepository.save(addProfileUrlToUser)
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
@@ -21,7 +21,7 @@ class ProfileUrlRegistrationService(
     }
 
     fun profileUrlRegistered(user: User, profileUrl: String) {
-        val addProfileUrlToUser = User(
+        val userUpdatedProfileUrl = User(
             user.userId,
             user.authenticationId,
             user.name,
@@ -32,6 +32,6 @@ class ProfileUrlRegistrationService(
             profileUrl
         )
 
-        userRepository.save(addProfileUrlToUser)
+        userRepository.save(userUpdatedProfileUrl)
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
@@ -17,10 +17,10 @@ class ProfileUrlRegistrationService(
         val user = userRepository.findByAuthenticationId(authenticationId)
             ?: throw ExpectedException("user를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
 
-        profileUrlRegistration(user, profileUrl)
+        profileUrlRegistered(user, profileUrl)
     }
 
-    fun profileUrlRegistration(user: User, profileUrl: String) {
+    fun profileUrlRegistered(user: User, profileUrl: String) {
         val addProfileUrlToUser = User(
             user.userId,
             user.authenticationId,

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -92,6 +92,10 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.POST, "/api/v1/mentee").hasAnyRole(
                 Authority.UNAUTHENTICATED.name
             )
+            // /user
+            .mvcMatchers("/api/v1/user/**").hasAnyRole(
+                Authority.USER.name
+            )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(
                 Authority.USER.name


### PR DESCRIPTION
## 개요

User 엔티티의 profileUrl을 등록 하는 로직을 구현하였습니다.

## 본문 

원래 mentor 등록할때 profileUrl도 같이 등록을 해야하는데 FE 사정으로 인해서 추가로 profileUrl 단독으로 등록하는 api를 요청하셔서 구현하였습니다.