### PR TITLE
profileUrl을 pathVariable에서 RequestBody로 받도록 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/controller/UserController.kt
@@ -4,9 +4,11 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.gsmNetworking.common.manager.AuthenticatedUserManager
+import team.themoment.gsmNetworking.domain.user.dto.ProfileUrlRegistrationDto
 import team.themoment.gsmNetworking.domain.user.service.ProfileUrlRegistrationService
 
 @RestController
@@ -16,10 +18,10 @@ class UserController(
     private val profileUrlRegistrationService: ProfileUrlRegistrationService
 ) {
 
-    @PostMapping("/profile/{profileUrl}")
-    fun profileUrlRegistration(@PathVariable profileUrl: String): ResponseEntity<Void> {
+    @PostMapping("/profile-url")
+    fun profileUrlRegistration(@RequestBody dto: ProfileUrlRegistrationDto): ResponseEntity<Void> {
         val authenticationId = authenticatedUserManager.getName()
-        profileUrlRegistrationService.execute(authenticationId, profileUrl)
+        profileUrlRegistrationService.execute(authenticationId, dto)
         return ResponseEntity.status(HttpStatus.CREATED).build()
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/dto/ProfileUrlRegistrationDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/dto/ProfileUrlRegistrationDto.kt
@@ -1,0 +1,5 @@
+package team.themoment.gsmNetworking.domain.user.dto
+
+data class ProfileUrlRegistrationDto(
+    val profileUrl: String?
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/ProfileUrlRegistrationService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.common.exception.ExpectedException
 import team.themoment.gsmNetworking.domain.user.domain.User
+import team.themoment.gsmNetworking.domain.user.dto.ProfileUrlRegistrationDto
 import team.themoment.gsmNetworking.domain.user.repository.UserRepository
 
 @Service
@@ -13,14 +14,14 @@ class ProfileUrlRegistrationService(
     private val userRepository: UserRepository
 ) {
 
-    fun execute(authenticationId: Long, profileUrl: String) {
+    fun execute(authenticationId: Long, dto: ProfileUrlRegistrationDto) {
         val user = userRepository.findByAuthenticationId(authenticationId)
             ?: throw ExpectedException("user를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
 
-        profileUrlRegistered(user, profileUrl)
+        profileUrlRegistered(user, dto.profileUrl)
     }
 
-    fun profileUrlRegistered(user: User, profileUrl: String) {
+    fun profileUrlRegistered(user: User, profileUrl: String?) {
         val userUpdatedProfileUrl = User(
             user.userId,
             user.authenticationId,


### PR DESCRIPTION
## 개요

profileUrl을 pathVariable에서 RequestBody로 받도록 수정하였습니다.

## 본문

profileUrl을 pathVariable로 받을경우 url에 포함된 / 때문에 다른 api로 판단하게 되서 RequestBody로 받도록 수정하였습니다.