### PR TITLE
이미지를 반환시 s3 bucket 도메인 변경 로직 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/config/PropertiesScanConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/config/PropertiesScanConfig.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration
 import team.themoment.gsmNetworking.global.security.jwt.properties.JwtExpTimeProperties
 import team.themoment.gsmNetworking.global.security.jwt.properties.JwtProperties
 import team.themoment.gsmNetworking.global.security.oauth.properties.Oauth2Properties
+import team.themoment.gsmNetworking.thirdParty.aws.s3.properties.S3Properties
 
 @Configuration
 @ConfigurationPropertiesScan(
@@ -13,7 +14,8 @@ import team.themoment.gsmNetworking.global.security.oauth.properties.Oauth2Prope
         Oauth2Properties::class,
         JwtExpTimeProperties::class,
         JwtProperties::class,
-        EncryptProperties::class
+        EncryptProperties::class,
+        S3Properties::class
     ]
 )
 class PropertiesScanConfig

--- a/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/properties/S3Properties.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/properties/S3Properties.kt
@@ -7,6 +7,5 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConfigurationProperties("spring.cloud.aws.s3")
 class S3Properties(
     val bucketName: String,
-    val existingImageBucketDomain: String,
     val imageBucketDomain: String
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/properties/S3Properties.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/properties/S3Properties.kt
@@ -1,0 +1,12 @@
+package team.themoment.gsmNetworking.thirdParty.aws.s3.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("spring.cloud.aws.s3")
+class S3Properties(
+    val bucketName: String,
+    val existingImageBucketDomain: String,
+    val imageBucketDomain: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
@@ -26,7 +26,7 @@ class ImageUploadService(
                 ?: throw ExpectedException("파일 확장자가 존재 하지 않는 파일입니다.", HttpStatus.BAD_REQUEST)
             val fileName = createFileName(fileExtension)
             s3Template.upload(s3Properties.bucketName, fileName, multipartFile.inputStream, ObjectMetadata.builder().contentType(validateFileExtension(fileExtension)).build())
-            s3ImageBucketDomainChange(fileName)
+            addS3ImageBucketDomain(fileName)
         } catch (e: S3Exception) {
             throw ExpectedException("AWS S3에서 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR)
         }
@@ -43,7 +43,7 @@ class ImageUploadService(
         return fileExtension
     }
 
-    private fun s3ImageBucketDomainChange(fileName: String): String{
+    private fun addS3ImageBucketDomain(fileName: String): String{
         return s3Properties.imageBucketDomain + fileName
     }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
@@ -16,6 +16,10 @@ import java.util.*
 class ImageUploadService(
     @Value("\${spring.cloud.aws.s3.bucket-name}")
     private val bucketName: String,
+    @Value("\${spring.cloud.aws.s3.existing-image-bucket-domain}")
+    private val existingImageBucketDomain: String,
+    @Value("\${spring.cloud.aws.s3.image-bucket-domain}")
+    private val imageBucketDomain: String,
     private val s3Template: S3Template
 ) {
 
@@ -26,7 +30,7 @@ class ImageUploadService(
                 ?: throw ExpectedException("파일 확장자가 존재 하지 않는 파일입니다.", HttpStatus.BAD_REQUEST)
             val fileName = createFileName(fileExtension)
             val s3Resource = s3Template.upload(bucketName, fileName, multipartFile.inputStream, ObjectMetadata.builder().contentType(validateFileExtension(fileExtension)).build())
-            s3Resource.url.toString()
+            s3ImageBucketDomainChange(s3Resource.url.toString())
         } catch (e: S3Exception) {
             throw ExpectedException("AWS S3에서 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR)
         }
@@ -41,6 +45,11 @@ class ImageUploadService(
             throw ExpectedException("지원하지 않는 파일 확장자 입니다.", HttpStatus.BAD_REQUEST)
         }
         return fileExtension
+    }
+
+    private fun s3ImageBucketDomainChange(s3ResourceUrl: String): String{
+        val s3ImageKey = s3ResourceUrl.split(existingImageBucketDomain)
+        return imageBucketDomain + s3ImageKey[1]
     }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/thirdParty/aws/s3/service/ImageUploadService.kt
@@ -25,8 +25,8 @@ class ImageUploadService(
             val fileExtension = StringUtils.getFilenameExtension(originFileName)
                 ?: throw ExpectedException("파일 확장자가 존재 하지 않는 파일입니다.", HttpStatus.BAD_REQUEST)
             val fileName = createFileName(fileExtension)
-            val s3Resource = s3Template.upload(s3Properties.bucketName, fileName, multipartFile.inputStream, ObjectMetadata.builder().contentType(validateFileExtension(fileExtension)).build())
-            s3ImageBucketDomainChange(s3Resource.url.toString())
+            s3Template.upload(s3Properties.bucketName, fileName, multipartFile.inputStream, ObjectMetadata.builder().contentType(validateFileExtension(fileExtension)).build())
+            s3ImageBucketDomainChange(fileName)
         } catch (e: S3Exception) {
             throw ExpectedException("AWS S3에서 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR)
         }
@@ -43,9 +43,8 @@ class ImageUploadService(
         return fileExtension
     }
 
-    private fun s3ImageBucketDomainChange(s3ResourceUrl: String): String{
-        val s3ImageKey = s3ResourceUrl.split(s3Properties.existingImageBucketDomain)
-        return s3Properties.imageBucketDomain + s3ImageKey[1]
+    private fun s3ImageBucketDomainChange(fileName: String): String{
+        return s3Properties.imageBucketDomain + fileName
     }
 
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,7 +50,7 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       s3:
         bucket-name: ${AWS_BUCKET_NAME}
-        existing-image-bucket-domain: ${EXISTING-IMAGE-BUCKET_DOMAIN}
+        existing-image-bucket-domain: ${EXISTING_IMAGE_BUCKET_DOMAIN}
         image-bucket-domain: ${IMAGE_BUCKET_DOMAIN}
       region:
         static: ${AWS_REGION}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,7 +50,6 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       s3:
         bucket-name: ${AWS_BUCKET_NAME}
-        existing-image-bucket-domain: ${EXISTING_IMAGE_BUCKET_DOMAIN}
         image-bucket-domain: ${IMAGE_BUCKET_DOMAIN}
       region:
         static: ${AWS_REGION}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,6 +50,8 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       s3:
         bucket-name: ${AWS_BUCKET_NAME}
+        existing-image-bucket-domain: ${EXISTING-IMAGE-BUCKET_DOMAIN}
+        image-bucket-domain: ${IMAGE_BUCKET_DOMAIN}
       region:
         static: ${AWS_REGION}
       stack:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,7 +50,6 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       s3:
         bucket-name: ${AWS_BUCKET_NAME}
-        existing-image-bucket-domain: ${EXISTING-IMAGE-BUCKET_DOMAIN}
         image-bucket-domain: ${IMAGE_BUCKET_DOMAIN}
       region:
         static: ${AWS_REGION}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,6 +50,8 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       s3:
         bucket-name: ${AWS_BUCKET_NAME}
+        existing-image-bucket-domain: ${EXISTING-IMAGE-BUCKET_DOMAIN}
+        image-bucket-domain: ${IMAGE_BUCKET_DOMAIN}
       region:
         static: ${AWS_REGION}
       stack:


### PR DESCRIPTION
##  개요

이미지를 반환할때 s3 bucket 도메인을 변경 하였습니다.

## 본문

기존 이미지 url의 도메인과 s3 image key 값을 분리 시키고 정해둔 imageBucketDomain 뒤에 s3 이미지 키 값을 위치시키고 반환하도록 하였습니다.