### PR TITLE
광야 게시물 반환시 cursor 기반 페이지네이션 구현

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -7,12 +7,15 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.gsmNetworking.common.exception.ExpectedException
 import team.themoment.gsmNetworking.domain.gwangya.authentication.GwangyaAuthenticationManager
 import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsRegistrationDto
 import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaTokenDto
 import team.themoment.gsmNetworking.domain.gwangya.service.GenerateGwangyaPostsService
+import team.themoment.gsmNetworking.domain.gwangya.service.QueryGwangyaPostsService
 import team.themoment.gsmNetworking.domain.gwangya.service.QueryGwangyaTokenService
 import javax.validation.Valid
 
@@ -21,6 +24,7 @@ import javax.validation.Valid
 class GwangyaController(
     private val queryGwangyaTokenService: QueryGwangyaTokenService,
     private val generateGwangyaPostsService: GenerateGwangyaPostsService,
+    private val queryGwangyaPostsService: QueryGwangyaPostsService,
     private val gwangyaAuthenticationManager: GwangyaAuthenticationManager
 ) {
     @GetMapping("/token")
@@ -29,10 +33,23 @@ class GwangyaController(
         return ResponseEntity.ok(gwangyaToken)
     }
 
+    @GetMapping
+    fun queryGwangya(
+        @RequestHeader("gwangyaToken") gwangyaToken: String,
+        @RequestParam cursorId: Long,
+        @RequestParam pageSize: Int
+    ): ResponseEntity<List<GwangyaPostsDto>> {
+        checkGwangyaAuthentication(gwangyaToken)
+        if (pageSize < 0 || cursorId < 0)
+            throw ExpectedException("0이상부터 가능합니다.", HttpStatus.BAD_REQUEST)
+        val gwangyaPosts = queryGwangyaPostsService.execute(cursorId, pageSize)
+        return ResponseEntity.ok(gwangyaPosts)
+    }
+
     @PostMapping
     fun generateGwangya(
         @RequestHeader("gwangyaToken") gwangyaToken: String,
-        @Valid @RequestBody gwangyaDto: GwangyaPostsDto
+        @Valid @RequestBody gwangyaDto: GwangyaPostsRegistrationDto
     ): ResponseEntity<Void> {
         checkGwangyaAuthentication(gwangyaToken)
         generateGwangyaPostsService.execute(gwangyaDto)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -42,6 +42,8 @@ class GwangyaController(
         checkGwangyaAuthentication(gwangyaToken)
         if (pageSize < 0 || cursorId < 0)
             throw ExpectedException("0이상부터 가능합니다.", HttpStatus.BAD_REQUEST)
+        else if (pageSize > 20)
+            throw ExpectedException("페이지 크기는 20이하까지 가능합니다.", HttpStatus.BAD_REQUEST)
         val gwangyaPosts = queryGwangyaPostsService.execute(cursorId, pageSize)
         return ResponseEntity.ok(gwangyaPosts)
     }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -36,7 +36,7 @@ class GwangyaController(
     @GetMapping
     fun queryGwangya(
         @RequestHeader("gwangyaToken") gwangyaToken: String,
-        @RequestParam cursorId: Long,
+        @RequestParam("gwangyaId") cursorId: Long,
         @RequestParam pageSize: Int
     ): ResponseEntity<List<GwangyaPostsDto>> {
         checkGwangyaAuthentication(gwangyaToken)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/domain/Gwangya.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/domain/Gwangya.kt
@@ -12,6 +12,6 @@ class Gwangya(
     @Column(name = "content", nullable = false, length = 200)
     val content: String,
 
-    @Column(name = "generation_time", nullable = false)
-    val generationTime: LocalDateTime
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/domain/GwangyaToken.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/domain/GwangyaToken.kt
@@ -14,8 +14,7 @@ data class GwangyaToken(
     @Indexed
     val gwangyaToken: String,
 
-    @Indexed
-    val generationTime: LocalDateTime,
+    val createdAt: LocalDateTime,
 
     @TimeToLive
     val expirationTime: Long

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsDto.kt
@@ -1,10 +1,11 @@
 package team.themoment.gsmNetworking.domain.gwangya.dto
 
-import javax.validation.constraints.NotNull
-import javax.validation.constraints.Size
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
 
 data class GwangyaPostsDto(
-    @field:NotNull
-    @field:Size(max = 200)
-    val content: String
+    val id: Long,
+    val content: String,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val createdAt: LocalDateTime
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsRegistrationDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsRegistrationDto.kt
@@ -1,0 +1,10 @@
+package team.themoment.gsmNetworking.domain.gwangya.dto
+
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+
+data class GwangyaPostsRegistrationDto(
+    @field:NotNull
+    @field:Size(max = 200)
+    val content: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
@@ -1,0 +1,8 @@
+package team.themoment.gsmNetworking.domain.gwangya.repository
+
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+
+interface GwangyaCustomRepository {
+
+    fun findAll(cursorId: Long, pageSize: Int): List<GwangyaPostsDto>
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
@@ -4,5 +4,5 @@ import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
 
 interface GwangyaCustomRepository {
 
-    fun findAll(cursorId: Long, pageSize: Int): List<GwangyaPostsDto>
+    fun findPagebyCursorId(cursorId: Long, pageSize: Int): List<GwangyaPostsDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -29,10 +29,7 @@ class GwangyaCustomRepositoryImpl(
             .fetch();
     }
 
-    private fun gtCursorId(cursorId: Long?): BooleanExpression? {
-        return if (cursorId != null)
-            gwangya.gwangyaId.gt(cursorId)
-        else
-            null
+    private fun gtCursorId(cursorId: Long): BooleanExpression {
+        return gwangya.gwangyaId.gt(cursorId)
     }
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package team.themoment.gsmNetworking.domain.gwangya.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import team.themoment.gsmNetworking.domain.gwangya.domain.QGwangya.gwangya
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+
+class GwangyaCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : GwangyaCustomRepository {
+
+    override fun findAll(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    GwangyaPostsDto::class.java,
+                    gwangya.gwangyaId,
+                    gwangya.content,
+                    gwangya.createdAt
+                )
+            )
+            .from(gwangya)
+            .where(
+                gtCursorId(cursorId),
+            )
+            .orderBy(gwangya.gwangyaId.asc())
+            .limit(pageSize.toLong())
+            .fetch();
+    }
+
+    private fun gtCursorId(cursorId: Long?): BooleanExpression? {
+        return if (cursorId != null)
+            gwangya.gwangyaId.gt(cursorId)
+        else
+            null
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -10,7 +10,7 @@ class GwangyaCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : GwangyaCustomRepository {
 
-    override fun findAll(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> {
+    override fun findPagebyCursorId(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> {
         return queryFactory
             .select(
                 Projections.constructor(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -29,7 +29,6 @@ class GwangyaCustomRepositoryImpl(
             .fetch();
     }
 
-    private fun gtCursorId(cursorId: Long): BooleanExpression {
-        return gwangya.gwangyaId.gt(cursorId)
-    }
+    private fun gtCursorId(cursorId: Long): BooleanExpression =
+        gwangya.gwangyaId.gt(cursorId)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaRepository.kt
@@ -2,7 +2,6 @@ package team.themoment.gsmNetworking.domain.gwangya.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.themoment.gsmNetworking.domain.gwangya.domain.Gwangya
-import java.util.UUID
 
-interface GwangyaRepository : CrudRepository<Gwangya, UUID> {
+interface GwangyaRepository : CrudRepository<Gwangya, Long>, GwangyaCustomRepository {
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/GenerateGwangyaPostsService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/GenerateGwangyaPostsService.kt
@@ -3,7 +3,7 @@ package team.themoment.gsmNetworking.domain.gwangya.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.domain.gwangya.domain.Gwangya
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsRegistrationDto
 import team.themoment.gsmNetworking.domain.gwangya.repository.GwangyaRepository
 import java.time.LocalDateTime
 
@@ -13,11 +13,11 @@ class GenerateGwangyaPostsService(
     private val gwangyaRepository: GwangyaRepository
 ) {
 
-    fun execute(gwangyaPostsDto: GwangyaPostsDto) {
+    fun execute(gwangyaPostsDto: GwangyaPostsRegistrationDto) {
 
         val gwangyaPosts = Gwangya(
             content = gwangyaPostsDto.content,
-            generationTime = LocalDateTime.now()
+            createdAt = LocalDateTime.now()
         )
 
         gwangyaRepository.save(gwangyaPosts)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostsService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostsService.kt
@@ -12,5 +12,5 @@ class QueryGwangyaPostsService(
 ) {
 
     fun execute(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> =
-        gwangyaRepository.findAll(cursorId, pageSize)
+        gwangyaRepository.findPagebyCursorId(cursorId, pageSize)
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostsService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostsService.kt
@@ -1,0 +1,16 @@
+package team.themoment.gsmNetworking.domain.gwangya.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.repository.GwangyaCustomRepository
+
+@Service
+@Transactional(readOnly = true)
+class QueryGwangyaPostsService(
+    private val gwangyaRepository: GwangyaCustomRepository
+) {
+
+    fun execute(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> =
+        gwangyaRepository.findAll(cursorId, pageSize)
+}


### PR DESCRIPTION
## 개요

- 광야 게시물 리스트를 반환하는 로직 구현
- cursor 기반 페이지네이션 구현

## 본문

광야 게시물들을 반환할때 쿼리메소드 방식으로 offset 기반 페이지네이션을 구현했을시에 생기는 게시물 중복 문제와 성능문제를 해결하기 위해서
queryDsl을 사용해서 cursor 기반 페이지 네이션을 구현하였습니다.

cursor 기반 페이지네이션을 처음 만들어봐서 이상한점 피드백 부탁드립니다.

## 기타
디코에서 리뷰 받았던 필드명을 generationTime -> createdAt으로 수정하였습니다.