### PR TITLE
광야 요구사항과 다른 부분 수정과 첫 리스트 요청 로직 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -40,7 +40,7 @@ class GwangyaController(
         @RequestParam pageSize: Int
     ): ResponseEntity<List<GwangyaPostsDto>> {
         checkGwangyaAuthentication(gwangyaToken)
-        if (pageSize < 0 || cursorId < 0)
+        if (pageSize < 0 || cursorId < 0L)
             throw ExpectedException("0이상부터 가능합니다.", HttpStatus.BAD_REQUEST)
         else if (pageSize > 20)
             throw ExpectedException("페이지 크기는 20이하까지 가능합니다.", HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -11,7 +11,7 @@ class GwangyaCustomRepositoryImpl(
 ) : GwangyaCustomRepository {
 
     override fun findPagebyCursorId(cursorId: Long, pageSize: Int): List<GwangyaPostsDto> {
-        return queryFactory
+        val query = queryFactory
             .select(
                 Projections.constructor(
                     GwangyaPostsDto::class.java,
@@ -21,14 +21,20 @@ class GwangyaCustomRepositoryImpl(
                 )
             )
             .from(gwangya)
-            .where(
-                gtCursorId(cursorId),
-            )
-            .orderBy(gwangya.gwangyaId.asc())
+
+        if (cursorId > 0L) {
+            query
+                .where(
+                    ltCursorId(cursorId),
+                )
+        }
+
+        return query
+            .orderBy(gwangya.gwangyaId.desc())
             .limit(pageSize.toLong())
             .fetch();
     }
 
-    private fun gtCursorId(cursorId: Long): BooleanExpression =
-        gwangya.gwangyaId.gt(cursorId)
+    private fun ltCursorId(cursorId: Long): BooleanExpression =
+        gwangya.gwangyaId.lt(cursorId)
 }


### PR DESCRIPTION
## 개요

- cursorId기준으로 게시물을 가져올때 `.gt()` -> `lt()` 변경
- 게시물 순서를 `.asc()` -> `.desc()` 변경
-  첫 광야 리스트 요청시 최신글부터 반환

## 본문

광야 요구사항을 잘못 이해해서 gt로 가져와서 오름차순으로 반환하던 값을 lt로 가져와서 내림차순으로 반환하도록 수정하였습니다.
+ 처음 리스트 요청할때 0으로 요청시에 가장 최신글부터 pageSize만큼 반환하도록 로직을 추가하였습니다.