### PR TITLE
광야 게시물 등록시 content 공백도 허용하지 않도록 변경

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsRegistrationDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostsRegistrationDto.kt
@@ -1,10 +1,10 @@
 package team.themoment.gsmNetworking.domain.gwangya.dto
 
-import javax.validation.constraints.NotNull
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
 data class GwangyaPostsRegistrationDto(
-    @field:NotNull
+    @field:NotBlank
     @field:Size(max = 200)
     val content: String
 )


### PR DESCRIPTION
## 개요

광야 게시물 등록시 content 필드를 NotNull에서 NotBlank로 변경하여서 공백도 허용하지 않도록 변경하였습니다.