### PR TITLE
광야 게시물 생성후 반환 시 변수명을 직관적으로 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -54,8 +54,8 @@ class GwangyaController(
         @Valid @RequestBody gwangyaDto: GwangyaPostsRegistrationDto
     ): ResponseEntity<GwangyaPostsDto> {
         checkGwangyaAuthentication(gwangyaToken)
-        val gwangyaPost = generateGwangyaPostsService.execute(gwangyaDto)
-        return ResponseEntity.status(HttpStatus.CREATED).body(gwangyaPost)
+        val savedGwangyaPost = generateGwangyaPostsService.execute(gwangyaDto)
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedGwangyaPost)
     }
 
     private fun checkGwangyaAuthentication(gwangyaToken: String) {


### PR DESCRIPTION
## 개요

광야 게시물 생성후 반환 시 변수명을 직관적으로 수정

## 본문

광야 게시물 생성후 서비스에서 리턴된 dto를 담는 변수 이름을 직관적으로 수정하였습니다.

받은 코멘트
https://github.com/themoment-team/GSM-Networking-server/pull/91#discussion_r1414902956