### PR TITLE
광야 게시글을 지칭하는 명사를 posts에서 post로 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/controller/GwangyaController.kt
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.themoment.gsmNetworking.common.exception.ExpectedException
 import team.themoment.gsmNetworking.domain.gwangya.authentication.GwangyaAuthenticationManager
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsRegistrationDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostRegistrationDto
 import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaTokenDto
-import team.themoment.gsmNetworking.domain.gwangya.service.GenerateGwangyaPostsService
-import team.themoment.gsmNetworking.domain.gwangya.service.QueryGwangyaPostsService
+import team.themoment.gsmNetworking.domain.gwangya.service.GenerateGwangyaPostService
+import team.themoment.gsmNetworking.domain.gwangya.service.QueryGwangyaPostService
 import team.themoment.gsmNetworking.domain.gwangya.service.QueryGwangyaTokenService
 import javax.validation.Valid
 
@@ -23,8 +23,8 @@ import javax.validation.Valid
 @RequestMapping("api/v1/gwangya")
 class GwangyaController(
     private val queryGwangyaTokenService: QueryGwangyaTokenService,
-    private val generateGwangyaPostsService: GenerateGwangyaPostsService,
-    private val queryGwangyaPostsService: QueryGwangyaPostsService,
+    private val generateGwangyaPostService: GenerateGwangyaPostService,
+    private val queryGwangyaPostService: QueryGwangyaPostService,
     private val gwangyaAuthenticationManager: GwangyaAuthenticationManager
 ) {
     @GetMapping("/token")
@@ -38,23 +38,23 @@ class GwangyaController(
         @RequestHeader("gwangyaToken") gwangyaToken: String,
         @RequestParam("gwangyaId") cursorId: Long,
         @RequestParam pageSize: Long
-    ): ResponseEntity<List<GwangyaPostsDto>> {
+    ): ResponseEntity<List<GwangyaPostDto>> {
         checkGwangyaAuthentication(gwangyaToken)
         if (pageSize < 0L || cursorId < 0L)
             throw ExpectedException("0이상부터 가능합니다.", HttpStatus.BAD_REQUEST)
         else if (pageSize > 20L)
             throw ExpectedException("페이지 크기는 20이하까지 가능합니다.", HttpStatus.BAD_REQUEST)
-        val gwangyaPosts = queryGwangyaPostsService.execute(cursorId, pageSize)
+        val gwangyaPosts = queryGwangyaPostService.execute(cursorId, pageSize)
         return ResponseEntity.ok(gwangyaPosts)
     }
 
     @PostMapping
     fun generateGwangya(
         @RequestHeader("gwangyaToken") gwangyaToken: String,
-        @Valid @RequestBody gwangyaDto: GwangyaPostsRegistrationDto
-    ): ResponseEntity<GwangyaPostsDto> {
+        @Valid @RequestBody gwangyaDto: GwangyaPostRegistrationDto
+    ): ResponseEntity<GwangyaPostDto> {
         checkGwangyaAuthentication(gwangyaToken)
-        val gwangyaPost = generateGwangyaPostsService.execute(gwangyaDto)
+        val gwangyaPost = generateGwangyaPostService.execute(gwangyaDto)
         return ResponseEntity.status(HttpStatus.CREATED).body(gwangyaPost)
     }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostDto.kt
@@ -3,7 +3,7 @@ package team.themoment.gsmNetworking.domain.gwangya.dto
 import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.LocalDateTime
 
-data class GwangyaPostsDto(
+data class GwangyaPostDto(
     val id: Long,
     val content: String,
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostRegistrationDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/dto/GwangyaPostRegistrationDto.kt
@@ -3,7 +3,7 @@ package team.themoment.gsmNetworking.domain.gwangya.dto
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
-data class GwangyaPostsRegistrationDto(
+data class GwangyaPostRegistrationDto(
     @field:NotBlank
     @field:Size(max = 200)
     val content: String

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepository.kt
@@ -1,10 +1,10 @@
 package team.themoment.gsmNetworking.domain.gwangya.repository
 
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostDto
 
 interface GwangyaCustomRepository {
 
-    fun findPagebyCursorId(cursorId: Long, pageSize: Long): List<GwangyaPostsDto>
+    fun findPagebyCursorId(cursorId: Long, pageSize: Long): List<GwangyaPostDto>
 
-    fun findPageWithRecentPosts(pageSize: Long): List<GwangyaPostsDto>
+    fun findPageWithRecentPosts(pageSize: Long): List<GwangyaPostDto>
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/repository/GwangyaCustomRepositoryImpl.kt
@@ -4,17 +4,17 @@ import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import team.themoment.gsmNetworking.domain.gwangya.domain.QGwangya.gwangya
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostDto
 
 class GwangyaCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : GwangyaCustomRepository {
 
-    override fun findPagebyCursorId(cursorId: Long, pageSize: Long): List<GwangyaPostsDto> {
+    override fun findPagebyCursorId(cursorId: Long, pageSize: Long): List<GwangyaPostDto> {
         return queryFactory
             .select(
                 Projections.constructor(
-                    GwangyaPostsDto::class.java,
+                    GwangyaPostDto::class.java,
                     gwangya.gwangyaId,
                     gwangya.content,
                     gwangya.createdAt
@@ -32,11 +32,11 @@ class GwangyaCustomRepositoryImpl(
     private fun ltCursorId(cursorId: Long): BooleanExpression =
         gwangya.gwangyaId.lt(cursorId)
 
-    override fun findPageWithRecentPosts(pageSize: Long): List<GwangyaPostsDto> {
+    override fun findPageWithRecentPosts(pageSize: Long): List<GwangyaPostDto> {
         return queryFactory
             .select(
                 Projections.constructor(
-                    GwangyaPostsDto::class.java,
+                    GwangyaPostDto::class.java,
                     gwangya.gwangyaId,
                     gwangya.content,
                     gwangya.createdAt

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/GenerateGwangyaPostService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/GenerateGwangyaPostService.kt
@@ -3,27 +3,27 @@ package team.themoment.gsmNetworking.domain.gwangya.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.themoment.gsmNetworking.domain.gwangya.domain.Gwangya
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsRegistrationDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostRegistrationDto
 import team.themoment.gsmNetworking.domain.gwangya.repository.GwangyaRepository
 import java.time.LocalDateTime
 
 @Service
 @Transactional(rollbackFor = [Exception::class])
-class GenerateGwangyaPostsService(
+class GenerateGwangyaPostService(
     private val gwangyaRepository: GwangyaRepository
 ) {
 
-    fun execute(gwangyaPostsDto: GwangyaPostsRegistrationDto): GwangyaPostsDto {
+    fun execute(gwangyaPostDto: GwangyaPostRegistrationDto): GwangyaPostDto {
 
-        val gwangyaPosts = Gwangya(
-            content = gwangyaPostsDto.content,
+        val gwangyaPost = Gwangya(
+            content = gwangyaPostDto.content,
             createdAt = LocalDateTime.now()
         )
 
-        val savedGwangyaPost = gwangyaRepository.save(gwangyaPosts)
+        val savedGwangyaPost = gwangyaRepository.save(gwangyaPost)
 
-        return GwangyaPostsDto(
+        return GwangyaPostDto(
             savedGwangyaPost.gwangyaId,
             savedGwangyaPost.content,
             savedGwangyaPost.createdAt

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/gwangya/service/QueryGwangyaPostService.kt
@@ -2,16 +2,16 @@ package team.themoment.gsmNetworking.domain.gwangya.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostsDto
+import team.themoment.gsmNetworking.domain.gwangya.dto.GwangyaPostDto
 import team.themoment.gsmNetworking.domain.gwangya.repository.GwangyaCustomRepository
 
 @Service
 @Transactional(readOnly = true)
-class QueryGwangyaPostsService(
+class QueryGwangyaPostService(
     private val gwangyaRepository: GwangyaCustomRepository
 ) {
 
-    fun execute(cursorId: Long, pageSize: Long): List<GwangyaPostsDto> =
+    fun execute(cursorId: Long, pageSize: Long): List<GwangyaPostDto> =
         if (cursorId == 0L)
             gwangyaRepository.findPageWithRecentPosts(pageSize)
         else


### PR DESCRIPTION
## 개요

광야 게시글을 지칭하는 명사를 posts에서 post로 수정

## 본문

기존 광야 게시글을 지칭하는 명사인 posts는 게시물이라는 의미로 지칭하였었는데 복수 명사이므로 수정하였습니다.