### PR TITLE
채팅 기능 리팩토링

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/common/socket/sender/StompSender.kt
@@ -68,6 +68,6 @@ interface StompSender {
      * @return 에러 메시지
      */
     fun createErrorMessage(ex: StompException): StompMessage<StompErrorResponse> =
-        StompMessage(StompErrorResponse(ex.code, ex.message), GlobalMessageCode.ERROR)
+        StompMessage(StompErrorResponse(ex.code, ex.message), GlobalMessageCode.ERROR, StompMessage.MessageType.ERROR)
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Header.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/Header.kt
@@ -5,11 +5,7 @@ import javax.persistence.*
 
 
 @Entity
-@Table(
-    name = "header", indexes = [Index(name = "idx_user1_user2", columnList = "user1_id, user2_id", unique = true),
-        Index(name = "idx_user2_time", columnList = "user2_id, recent_message_id desc", unique = true),
-        Index(name = "idx_user1_time", columnList = "user1_id, recent_message_id desc", unique = true)]
-)
+@Table(name = "header", indexes = [Index(name = "idx_user1_user2", columnList = "user1_id, user2_id", unique = true)])
 // Header는 Message에 의존적임.
 // Message의 빠른 조회를 위해 비정규화 된 값 값이라고 봐도 됨
 class Header private constructor(

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserHeaderType.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserHeaderType.kt
@@ -1,6 +1,0 @@
-package team.themoment.gsmNetworking.domain.message.domain
-
-enum class UserHeaderType {
-    User1,
-    User2
-}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserHeaderType.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserHeaderType.kt
@@ -1,0 +1,6 @@
+package team.themoment.gsmNetworking.domain.message.domain
+
+enum class UserHeaderType {
+    User1,
+    User2
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/domain/UserMessageInfo.kt
@@ -3,14 +3,15 @@ package team.themoment.gsmNetworking.domain.message.domain
 import javax.persistence.*
 
 @Entity
-@Table(
-    name = "user_message_info",
-    indexes = [Index(name = "idx_user_id_opponent_user_id", columnList = "user_id, opponent_user_id", unique = true)]
-)
+@Table
 class UserMessageInfo(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_message_info_id")
     val userMessageInfoId: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "header_id", nullable = false)
+    val header: Header,
 
     @Column(name = "user_id", nullable = false)
     val userId: Long,
@@ -24,6 +25,7 @@ class UserMessageInfo(
     fun updateLastViewedEpochMilli(newLastViewedEpochMilli: Long): UserMessageInfo {
         return UserMessageInfo(
             userMessageInfoId = this.userMessageInfoId,
+            header = this.header,
             userId = this.userId,
             opponentUserId = this.opponentUserId,
             lastViewedEpochMilli = newLastViewedEpochMilli

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageMetaDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/dto/domain/MessageMetaDto.kt
@@ -8,5 +8,5 @@ data class MessageMetaDto(
     val user2Id: Long,
     val messageDirection: Message.MessageDirection,
     val recentMessageId: UUID,
-    val lastViewedChatId: UUID?
+    val lastViewedEpochMilli: Long
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/MessageCustomRepository.kt
@@ -2,6 +2,7 @@ package team.themoment.gsmNetworking.domain.message.repository
 
 import team.themoment.gsmNetworking.domain.message.domain.Header
 import team.themoment.gsmNetworking.domain.message.domain.Message
+import team.themoment.gsmNetworking.domain.message.domain.UserMessageInfo
 import team.themoment.gsmNetworking.domain.message.dto.domain.MessageMetaDto
 import team.themoment.gsmNetworking.domain.message.dto.domain.MessageDto
 import team.themoment.gsmNetworking.domain.message.enums.QueryDirection
@@ -45,4 +46,5 @@ interface MessageCustomRepository {
      * @return nullable [Message]
      */
     fun findHeaderBetweenUsers(user1Id: Long, user2Id: Long): Header?
+    fun findPairUserMessageInfoBetweenUsers(user1Id: Long, user2Id: Long): Pair<UserMessageInfo, UserMessageInfo>?
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/repository/UserMessageInfoRepository.kt
@@ -4,9 +4,4 @@ import org.springframework.data.repository.CrudRepository
 import team.themoment.gsmNetworking.domain.message.domain.UserMessageInfo
 
 
-interface UserMessageInfoRepository : CrudRepository<UserMessageInfo, Long> {
-    fun findByUserId(userId: Long): UserMessageInfo?
-
-    fun findByUserIdAndOpponentUserId(userId: Long, opponentUserId: Long): UserMessageInfo?
-
-}
+interface UserMessageInfoRepository : CrudRepository<UserMessageInfo, Long>

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/CheckMessageServiceImpl.kt
@@ -2,6 +2,8 @@ package team.themoment.gsmNetworking.domain.message.service.impl
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.gsmNetworking.domain.message.repository.HeaderRepository
+import team.themoment.gsmNetworking.domain.message.repository.MessageRepository
 import team.themoment.gsmNetworking.domain.message.repository.UserMessageInfoRepository
 import team.themoment.gsmNetworking.domain.message.service.CheckMessageService
 import java.time.Instant
@@ -9,13 +11,19 @@ import java.time.Instant
 @Service
 class CheckMessageServiceImpl(
     private val userMessageInfoRepository: UserMessageInfoRepository,
+    private val messageRepository: MessageRepository
 ) : CheckMessageService {
 
     @Transactional
     override fun execute(toUserId: Long, fromUserId: Long, time: Instant) {
+        val (user1Id, user2Id) = if (toUserId < fromUserId) toUserId to fromUserId else fromUserId to toUserId
 
-        val fromUserMessageInfo = userMessageInfoRepository.findByUserIdAndOpponentUserId(fromUserId, toUserId)
-            ?: throw IllegalArgumentException("유효하지 않은 UserId. $fromUserId 와 $toUserId 사이의 메시지를 찾을 수 없습니다.")
+        val userMessageInfoPair = messageRepository.findPairUserMessageInfoBetweenUsers(user1Id, user2Id)
+            ?: throw IllegalArgumentException("유효하지 않은 UserId. $fromUserId 와 $toUserId 사이의 메시지 찾을 수 없습니다.")
+
+        val fromUserMessageInfo =
+            if (userMessageInfoPair.first.userId == fromUserId) userMessageInfoPair.first
+            else userMessageInfoPair.second
 
         if (time.toEpochMilli() > fromUserMessageInfo.lastViewedEpochMilli) {
             userMessageInfoRepository.save(fromUserMessageInfo.updateLastViewedEpochMilli(time.toEpochMilli()))

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/message/service/impl/SaveMessageServiceImpl.kt
@@ -72,9 +72,9 @@ class SaveMessageServiceImpl(
             direction = direction,
             content = content
         )
-        // 둘 다 상대방의 채팅을 아직 확인하지 않았으므로 기본값이 부여됨
-        userMessageInfoRepository.save(UserMessageInfo(userId = user1Id, opponentUserId = user2Id))
-        userMessageInfoRepository.save(UserMessageInfo(userId = user2Id, opponentUserId = user1Id))
+        // 둘 다 채팅을 아직 확인하지 않았으므로 기본값이 부여됨
+        userMessageInfoRepository.save(UserMessageInfo(userId = user1Id, opponentUserId = user2Id, header = newHeader))
+        userMessageInfoRepository.save(UserMessageInfo(userId = user2Id, opponentUserId = user1Id, header = newHeader))
 
         return messageRepository.save(newMessage)
     }


### PR DESCRIPTION
## 개요
채팅 기능 리팩토링을 진행하였습니다.

#### `MessageMetaDto` 필드 이름과 타입이 잘못 지정된 문제
`MessageMetaDto`의 필드를 알맞게 수정   
`lastViewedChatId: UUID?` -> `lastViewedEpochMilli: Long
`
#### `UserMessageInfo`에 `Header` 연관관계 추가 및 기존 `MessageCustomRepository` 쿼리 메서드 추가
`UserMessageInfo`에 `Header` 연관관계 추가
`UserMessageInfoRepository`의 쿼리 기능을 `MessageCustomRepository`로 이동