### PR TITLE
Develop 브랜치 CD 수정

### DIFF
--- a/.github/workflows/GSM-Networking-Develop-CD.yml
+++ b/.github/workflows/GSM-Networking-Develop-CD.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/GSM-Networking-Develop-Merge-CI.yml
+++ b/.github/workflows/GSM-Networking-Develop-Merge-CI.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
## 개요

- Develop 브랜치 CD 수정

## 본문

기존 디벨롭 브랜치의 CI/CD 코드를 가져오는 브랜치 설정이 안되어있어서 main 브랜치 기준으로 배포가 되는거 같아서 수정하였습니다.