### PR TITLE
Board, Comment 엔티티 연관관계 어노테이션 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/domain/Board.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/domain/Board.kt
@@ -19,7 +19,7 @@ class Board (
     @Column(name = "board_category")
     val boardCategory: BoardCategory,
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "author_id")
     val author: User,
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/domain/Comment.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/domain/Comment.kt
@@ -25,7 +25,7 @@ class Comment(
     @JoinColumn(name = "reply_comment_id")
     val replyComment: List<Comment> = ArrayList(),
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "author_id")
     val author: User
 ): BaseIdTimestampEntity();


### PR DESCRIPTION
Board, Comment 엔티티의 작성자 컬럼의 연관관계 어노테이션을 `@OneToOne` -> `@ManyToOne` 으로 수정하였습니다.