### PR TITLE
임시 프로필 이미지 번호 필드 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
@@ -76,7 +76,8 @@ class BoardService (
             author = AuthorDto(
                 name = currentBoard.author.name,
                 generation = currentBoard.author.generation,
-                profileUrl = currentBoard.author.profileUrl
+                profileUrl = currentBoard.author.profileUrl,
+                temporaryImgNumber = currentBoard.author.temporaryImgNumber
             ),
             createdAt = currentBoard.createdAt,
             comments = getFindComments(findComments)
@@ -90,7 +91,8 @@ class BoardService (
             author = AuthorDto(
                 name = it.author.name,
                 generation = it.author.generation,
-                profileUrl = it.author.profileUrl
+                profileUrl = it.author.profileUrl,
+                temporaryImgNumber = it.author.temporaryImgNumber
             ),
             replies = getFindReplies(it)
         ) }
@@ -105,7 +107,8 @@ class BoardService (
                     author = AuthorDto(
                         name = reply.author.name,
                         generation = reply.author.generation,
-                        profileUrl = reply.author.profileUrl
+                        profileUrl = reply.author.profileUrl,
+                        temporaryImgNumber = reply.author.temporaryImgNumber
                     ),
                     replyCommentId = reply.repliedComment?.id
                 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
@@ -77,7 +77,7 @@ class BoardService (
                 name = currentBoard.author.name,
                 generation = currentBoard.author.generation,
                 profileUrl = currentBoard.author.profileUrl,
-                temporaryImgNumber = currentBoard.author.temporaryImgNumber
+                defaultImgNumber = currentBoard.author.defaultImgNumber
             ),
             createdAt = currentBoard.createdAt,
             comments = getFindComments(findComments)
@@ -92,7 +92,7 @@ class BoardService (
                 name = it.author.name,
                 generation = it.author.generation,
                 profileUrl = it.author.profileUrl,
-                temporaryImgNumber = it.author.temporaryImgNumber
+                defaultImgNumber = it.author.defaultImgNumber
             ),
             replies = getFindReplies(it)
         ) }
@@ -108,7 +108,7 @@ class BoardService (
                         name = reply.author.name,
                         generation = reply.author.generation,
                         profileUrl = reply.author.profileUrl,
-                        temporaryImgNumber = reply.author.temporaryImgNumber
+                        defaultImgNumber = reply.author.defaultImgNumber
                     ),
                     replyCommentId = reply.repliedComment?.id
                 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/dto/AuthorDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/dto/AuthorDto.kt
@@ -3,5 +3,6 @@ package team.themoment.gsmNetworking.domain.comment.dto
 data class AuthorDto (
     val name: String,
     val generation: Int,
-    val profileUrl: String?
+    val profileUrl: String?,
+    val temporaryImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/dto/AuthorDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/dto/AuthorDto.kt
@@ -4,5 +4,5 @@ data class AuthorDto (
     val name: String,
     val generation: Int,
     val profileUrl: String?,
-    val temporaryImgNumber: Int
+    val defaultImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/service/impl/CommentService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/service/impl/CommentService.kt
@@ -59,7 +59,7 @@ class CommentService (
                 name = savedComment.author.name,
                 generation = savedComment.author.generation,
                 profileUrl = savedComment.author.profileUrl,
-                temporaryImgNumber = savedComment.author.temporaryImgNumber
+                defaultImgNumber = savedComment.author.defaultImgNumber
             )
         )
     }
@@ -78,7 +78,7 @@ class CommentService (
                 name = comment.author.name,
                 generation = comment.author.generation,
                 profileUrl = comment.author.profileUrl,
-                temporaryImgNumber = comment.author.temporaryImgNumber
+                defaultImgNumber = comment.author.defaultImgNumber
             ),
             replies = getReplies(findReplies)
         )
@@ -93,7 +93,7 @@ class CommentService (
                     name = it.author.name,
                     generation = it.author.generation,
                     profileUrl = it.author.profileUrl,
-                    temporaryImgNumber = it.author.temporaryImgNumber
+                    defaultImgNumber = it.author.defaultImgNumber
                 ),
                 replyCommentId = it.repliedComment?.id
             )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/service/impl/CommentService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/service/impl/CommentService.kt
@@ -58,7 +58,8 @@ class CommentService (
             author = AuthorDto (
                 name = savedComment.author.name,
                 generation = savedComment.author.generation,
-                profileUrl = savedComment.author.profileUrl
+                profileUrl = savedComment.author.profileUrl,
+                temporaryImgNumber = savedComment.author.temporaryImgNumber
             )
         )
     }
@@ -76,7 +77,8 @@ class CommentService (
             author = AuthorDto(
                 name = comment.author.name,
                 generation = comment.author.generation,
-                profileUrl = comment.author.profileUrl
+                profileUrl = comment.author.profileUrl,
+                temporaryImgNumber = comment.author.temporaryImgNumber
             ),
             replies = getReplies(findReplies)
         )
@@ -90,7 +92,8 @@ class CommentService (
                 author = AuthorDto(
                     name = it.author.name,
                     generation = it.author.generation,
-                    profileUrl = it.author.profileUrl
+                    profileUrl = it.author.profileUrl,
+                    temporaryImgNumber = it.author.temporaryImgNumber
                 ),
                 replyCommentId = it.repliedComment?.id
             )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
@@ -3,6 +3,7 @@ package team.themoment.gsmNetworking.domain.mentor.domain
 import team.themoment.gsmNetworking.common.domain.BaseIdTimestampEntity
 import team.themoment.gsmNetworking.domain.user.domain.User
 import javax.persistence.*
+import kotlin.random.Random
 
 /**
  * 멘토 정보를 저장하는 Entity 클래스 입니다.
@@ -13,11 +14,20 @@ class Mentor(
     @Column(nullable = false, name = "registered")
     val registered: Boolean,
 
-    @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int,
-
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    val user: User
-) : BaseIdTimestampEntity()
+    val user: User,
+
+    @Column(name = "temporary_img_number")
+    val temporaryImgNumber: Int
+) : BaseIdTimestampEntity() {
+
+    constructor(registered: Boolean, user: User) : this(registered, user, generateRandomNumber())
+
+    companion object {
+        private fun generateRandomNumber(): Int {
+            return Random.nextInt(0, 9)
+        }
+    }
+
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
@@ -13,6 +13,10 @@ class Mentor(
     @Column(nullable = false, name = "registered")
     val registered: Boolean,
 
+    @Column(name = "temporary_img_number")
+    val temporaryImgNumber: Int,
+
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: User

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
@@ -3,7 +3,6 @@ package team.themoment.gsmNetworking.domain.mentor.domain
 import team.themoment.gsmNetworking.common.domain.BaseIdTimestampEntity
 import team.themoment.gsmNetworking.domain.user.domain.User
 import javax.persistence.*
-import kotlin.random.Random
 
 /**
  * 멘토 정보를 저장하는 Entity 클래스 입니다.
@@ -17,13 +16,4 @@ class Mentor(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: User,
-
-    @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int = generateRandomNumber()
-) : BaseIdTimestampEntity() {
-    companion object {
-        private fun generateRandomNumber(): Int {
-            return Random.nextInt(1, 7)
-        }
-    }
-}
+) : BaseIdTimestampEntity()

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/Mentor.kt
@@ -19,15 +19,11 @@ class Mentor(
     val user: User,
 
     @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int
+    val temporaryImgNumber: Int = generateRandomNumber()
 ) : BaseIdTimestampEntity() {
-
-    constructor(registered: Boolean, user: User) : this(registered, user, generateRandomNumber())
-
     companion object {
         private fun generateRandomNumber(): Int {
-            return Random.nextInt(0, 9)
+            return Random.nextInt(1, 7)
         }
     }
-
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -37,5 +37,8 @@ class TempMentor(
     val position: String,
 
     @Column(nullable = false, name = "deleted")
-    var deleted: Boolean = false
+    var deleted: Boolean = false,
+
+    @Column(name = "temporary_img_number")
+    val temporaryImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -41,6 +41,6 @@ class TempMentor(
     @Column(nullable = false, name = "deleted")
     var deleted: Boolean = false,
 
-    @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int
+    @Column(name = "default_img_number")
+    val defaultImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -2,7 +2,9 @@ package team.themoment.gsmNetworking.domain.mentor.domain
 
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.Where
+import team.themoment.gsmNetworking.domain.user.domain.User
 import javax.persistence.*
+import kotlin.random.Random
 
 @Entity
 @Table(name = "temp_mentor")
@@ -40,5 +42,11 @@ class TempMentor(
     var deleted: Boolean = false,
 
     @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int
-)
+    val temporaryImgNumber: Int = generateRandomNumber()
+) {
+    companion object {
+        private fun generateRandomNumber(): Int {
+            return Random.nextInt(1, 7)
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -42,11 +42,5 @@ class TempMentor(
     var deleted: Boolean = false,
 
     @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int = generateRandomNumber()
-) {
-    companion object {
-        private fun generateRandomNumber(): Int {
-            return Random.nextInt(1, 7)
-        }
-    }
-}
+    val temporaryImgNumber: Int
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -12,5 +12,6 @@ data class MentorInfoDto(
     @field:JsonProperty("SNS")
     val sns: String?,
     val profileUrl: String?,
-    val registered: Boolean
+    val registered: Boolean,
+    val temporaryImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -13,5 +13,5 @@ data class MentorInfoDto(
     val sns: String?,
     val profileUrl: String?,
     val registered: Boolean,
-    val temporaryImgNumber: Int
+    val defaultImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MyMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MyMentorInfoDto.kt
@@ -12,5 +12,6 @@ data class MyMentorInfoDto(
     val sns: String?,
     val profileUrl: String?,
     val registered: Boolean,
+    val temporaryImgNumber: Int,
     val career: List<MyCareerInfoDto>
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MyMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MyMentorInfoDto.kt
@@ -12,6 +12,6 @@ data class MyMentorInfoDto(
     val sns: String?,
     val profileUrl: String?,
     val registered: Boolean,
-    val temporaryImgNumber: Int,
+    val defaultImgNumber: Int,
     val career: List<MyCareerInfoDto>
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
@@ -11,5 +11,5 @@ data class SearchTempMentorInfoDto(
     val company: CompanyInfoDto,
     @field:JsonProperty("SNS")
     val snsUrl: String?,
-    val temporaryImgNumber: Int
+    val defaultImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/SearchTempMentorInfoDto.kt
@@ -10,5 +10,6 @@ data class SearchTempMentorInfoDto(
     val position: String,
     val company: CompanyInfoDto,
     @field:JsonProperty("SNS")
-    val snsUrl: String?
+    val snsUrl: String?,
+    val temporaryImgNumber: Int
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
@@ -10,7 +10,8 @@ data class TempMentorInfoDto(
     val position: String,
     val company: CompanyInfoDto,
     @field:JsonProperty("SNS")
-    val snsUrl: String?
+    val snsUrl: String?,
+    val temporaryImgNumber: Int
 ) {
     fun toMentorInfoDto() = MentorInfoDto(
         id = id,
@@ -21,6 +22,7 @@ data class TempMentorInfoDto(
         company = company,
         sns = snsUrl,
         profileUrl = null,
-        registered = false
+        registered = false,
+        temporaryImgNumber = temporaryImgNumber
     )
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
@@ -11,7 +11,7 @@ data class TempMentorInfoDto(
     val company: CompanyInfoDto,
     @field:JsonProperty("SNS")
     val snsUrl: String?,
-    val temporaryImgNumber: Int
+    val defaultImgNumber: Int
 ) {
     fun toMentorInfoDto() = MentorInfoDto(
         id = id,
@@ -23,6 +23,6 @@ data class TempMentorInfoDto(
         sns = snsUrl,
         profileUrl = null,
         registered = false,
-        temporaryImgNumber = temporaryImgNumber
+        defaultImgNumber = defaultImgNumber
     )
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
@@ -42,7 +42,7 @@ class MentorCustomRepositoryImpl(
                 mentor.user.snsUrl,
                 mentor.user.profileUrl,
                 mentor.registered,
-                mentor.user.temporaryImgNumber
+                mentor.user.defaultImgNumber
             )
         )
             .from(mentor, career)
@@ -75,7 +75,7 @@ class MentorCustomRepositoryImpl(
                         mentor.user.snsUrl,
                         mentor.user.profileUrl,
                         mentor.registered,
-                        mentor.user.temporaryImgNumber,
+                        mentor.user.defaultImgNumber,
                         list(
                             Projections.constructor(
                                 MyCareerInfoDto::class.java,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
@@ -41,7 +41,8 @@ class MentorCustomRepositoryImpl(
                 ),
                 mentor.user.snsUrl,
                 mentor.user.profileUrl,
-                mentor.registered
+                mentor.registered,
+                mentor.temporaryImgNumber
             )
         )
             .from(mentor, career)
@@ -74,6 +75,7 @@ class MentorCustomRepositoryImpl(
                         mentor.user.snsUrl,
                         mentor.user.profileUrl,
                         mentor.registered,
+                        mentor.temporaryImgNumber,
                         list(
                             Projections.constructor(
                                 MyCareerInfoDto::class.java,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
@@ -42,7 +42,7 @@ class MentorCustomRepositoryImpl(
                 mentor.user.snsUrl,
                 mentor.user.profileUrl,
                 mentor.registered,
-                mentor.temporaryImgNumber
+                mentor.user.temporaryImgNumber
             )
         )
             .from(mentor, career)
@@ -75,7 +75,7 @@ class MentorCustomRepositoryImpl(
                         mentor.user.snsUrl,
                         mentor.user.profileUrl,
                         mentor.registered,
-                        mentor.temporaryImgNumber,
+                        mentor.user.temporaryImgNumber,
                         list(
                             Projections.constructor(
                                 MyCareerInfoDto::class.java,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
@@ -93,7 +93,8 @@ class TempMentorService(
                     name = tempMentor.companyName,
                     url = tempMentor.companyUrl
                 ),
-                snsUrl = tempMentor.sns
+                snsUrl = tempMentor.sns,
+                temporaryImgNumber = tempMentor.temporaryImgNumber
             )
         }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
@@ -40,7 +40,8 @@ class TempMentorService(
                     name = tempMentor.companyName,
                     url = tempMentor.companyUrl
                 ),
-                snsUrl = tempMentor.sns
+                snsUrl = tempMentor.sns,
+                temporaryImgNumber = tempMentor.temporaryImgNumber
             )
         }
 
@@ -68,7 +69,8 @@ class TempMentorService(
                 name = tempMentor.companyName,
                 url = tempMentor.companyUrl
             ),
-            snsUrl = tempMentor.sns
+            snsUrl = tempMentor.sns,
+            temporaryImgNumber = tempMentor.temporaryImgNumber
         )
     }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/service/impl/TempMentorService.kt
@@ -41,7 +41,7 @@ class TempMentorService(
                     url = tempMentor.companyUrl
                 ),
                 snsUrl = tempMentor.sns,
-                temporaryImgNumber = tempMentor.temporaryImgNumber
+                defaultImgNumber = tempMentor.defaultImgNumber
             )
         }
 
@@ -70,7 +70,7 @@ class TempMentorService(
                 url = tempMentor.companyUrl
             ),
             snsUrl = tempMentor.sns,
-            temporaryImgNumber = tempMentor.temporaryImgNumber
+            defaultImgNumber = tempMentor.defaultImgNumber
         )
     }
 
@@ -94,7 +94,7 @@ class TempMentorService(
                     url = tempMentor.companyUrl
                 ),
                 snsUrl = tempMentor.sns,
-                temporaryImgNumber = tempMentor.temporaryImgNumber
+                defaultImgNumber = tempMentor.defaultImgNumber
             )
         }
 

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -1,8 +1,10 @@
 package team.themoment.gsmNetworking.domain.user.domain
 
 import team.themoment.gsmNetworking.common.domain.BaseIdTimestampEntity
+import team.themoment.gsmNetworking.domain.mentor.domain.Mentor
 import team.themoment.gsmNetworking.domain.user.converter.EncryptConverter
 import javax.persistence.*
+import kotlin.random.Random
 
 /**
  * 사용자의 정보를 저장하는 Entity 클래스 입니다.
@@ -32,5 +34,14 @@ class User(
     val snsUrl: String?,
 
     @Column(nullable = true)
-    val profileUrl: String?
-) : BaseIdTimestampEntity()
+    val profileUrl: String?,
+
+    @Column(name = "temporary_img_number")
+    val temporaryImgNumber: Int = generateRandomNumber()
+) : BaseIdTimestampEntity() {
+    companion object {
+        private fun generateRandomNumber(): Int {
+            return Random.nextInt(1, 7)
+        }
+    }
+}

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -36,8 +36,8 @@ class User(
     @Column(nullable = true)
     val profileUrl: String?,
 
-    @Column(name = "temporary_img_number")
-    val temporaryImgNumber: Int = generateRandomNumber()
+    @Column(name = "default_img_number")
+    val defaultImgNumber: Int = generateRandomNumber()
 ) : BaseIdTimestampEntity() {
     companion object {
         private fun generateRandomNumber(): Int {

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
@@ -58,7 +58,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/a",
             profileUrl = "https://www.instagram.com/img/a",
             registered = true,
-            temporaryImgNumber = 0
+            defaultImgNumber = 0
         ),
         MentorInfoDto(
             id = 2L,
@@ -73,7 +73,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/b",
             profileUrl = "https://www.instagram.com/img/b",
             registered = true,
-            temporaryImgNumber = 1
+            defaultImgNumber = 1
         ),
         MentorInfoDto(
             id = 3L,
@@ -88,7 +88,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/c",
             profileUrl = "https://www.instagram.com/img/c",
             registered = true,
-            temporaryImgNumber = 2
+            defaultImgNumber = 2
         ),
         MentorInfoDto(
             id = 4L,
@@ -103,7 +103,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/d",
             profileUrl = "https://www.instagram.com/img/d",
             registered = true,
-            temporaryImgNumber = 3
+            defaultImgNumber = 3
         )
     )
 
@@ -119,7 +119,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 url = "https://www.ghi-company.com"
             ),
             snsUrl = "https://www.instagram.com/c",
-            temporaryImgNumber = 4
+            defaultImgNumber = 4
         ),
         TempMentorInfoDto(
             id = 11L,
@@ -132,7 +132,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 url = "https://www.jkl-company.com"
             ),
             snsUrl = "https://www.instagram.com/d",
-            temporaryImgNumber = 5
+            defaultImgNumber = 5
         ),
         TempMentorInfoDto(
             id = 12L,
@@ -145,7 +145,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 url = "https://www.mno-company.com"
             ),
             snsUrl = "https://www.instagram.com/e",
-            temporaryImgNumber = 6
+            defaultImgNumber = 6
         ),
         TempMentorInfoDto(
             id = 13L,
@@ -158,7 +158,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 url = "https://www.pqr-company.com"
             ),
             snsUrl = "https://www.instagram.com/f",
-            temporaryImgNumber = 1
+            defaultImgNumber = 1
         )
     )
 
@@ -175,7 +175,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
         sns = "https://www.instagram.com/a",
         profileUrl = "https://www.instagram.com/img/a",
         registered = true,
-        temporaryImgNumber = 2
+        defaultImgNumber = 2
     )
 
     val sameUserTempMentor = TempMentorInfoDto(
@@ -189,7 +189,7 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             url = "https://www.abc-company.com"
         ),
         snsUrl = "https://www.instagram.com/a",
-        temporaryImgNumber = 3
+        defaultImgNumber = 3
     )
 
     given("조회할 멘토, 임시 멘토 리스트와 예상 결과 리스트가 주어질 때") {

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
@@ -57,7 +57,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             ),
             sns = "https://www.instagram.com/a",
             profileUrl = "https://www.instagram.com/img/a",
-            registered = true
+            registered = true,
+            temporaryImgNumber = 0
         ),
         MentorInfoDto(
             id = 2L,
@@ -71,7 +72,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             ),
             sns = "https://www.instagram.com/b",
             profileUrl = "https://www.instagram.com/img/b",
-            registered = true
+            registered = true,
+            temporaryImgNumber = 1
         ),
         MentorInfoDto(
             id = 3L,
@@ -85,7 +87,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             ),
             sns = "https://www.instagram.com/c",
             profileUrl = "https://www.instagram.com/img/c",
-            registered = true
+            registered = true,
+            temporaryImgNumber = 2
         ),
         MentorInfoDto(
             id = 4L,
@@ -99,7 +102,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             ),
             sns = "https://www.instagram.com/d",
             profileUrl = "https://www.instagram.com/img/d",
-            registered = true
+            registered = true,
+            temporaryImgNumber = 3
         )
     )
 
@@ -114,7 +118,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 name = "GHI 회사",
                 url = "https://www.ghi-company.com"
             ),
-            snsUrl = "https://www.instagram.com/c"
+            snsUrl = "https://www.instagram.com/c",
+            temporaryImgNumber = 4
         ),
         TempMentorInfoDto(
             id = 11L,
@@ -126,7 +131,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 name = "JKL 회사",
                 url = "https://www.jkl-company.com"
             ),
-            snsUrl = "https://www.instagram.com/d"
+            snsUrl = "https://www.instagram.com/d",
+            temporaryImgNumber = 5
         ),
         TempMentorInfoDto(
             id = 12L,
@@ -138,7 +144,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 name = "MNO 회사",
                 url = "https://www.mno-company.com"
             ),
-            snsUrl = "https://www.instagram.com/e"
+            snsUrl = "https://www.instagram.com/e",
+            temporaryImgNumber = 6
         ),
         TempMentorInfoDto(
             id = 13L,
@@ -150,7 +157,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
                 name = "PQR 회사",
                 url = "https://www.pqr-company.com"
             ),
-            snsUrl = "https://www.instagram.com/f"
+            snsUrl = "https://www.instagram.com/f",
+            temporaryImgNumber = 1
         )
     )
 
@@ -166,7 +174,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
         ),
         sns = "https://www.instagram.com/a",
         profileUrl = "https://www.instagram.com/img/a",
-        registered = true
+        registered = true,
+        temporaryImgNumber = 2
     )
 
     val sameUserTempMentor = TempMentorInfoDto(
@@ -179,7 +188,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             name = "ABC 회사",
             url = "https://www.abc-company.com"
         ),
-        snsUrl = "https://www.instagram.com/a"
+        snsUrl = "https://www.instagram.com/a",
+        temporaryImgNumber = 3
     )
 
     given("조회할 멘토, 임시 멘토 리스트와 예상 결과 리스트가 주어질 때") {


### PR DESCRIPTION
## 개요

기존에 멘토 정보를 조회할때 프론트 단에서 `temporaryImgNumber` 랜덤 값을 생성하여 사용했습니다.

프론트 단에서 `hydration` 관련 이슈가 발생하여 서버에서 `temporaryImgNumber` 랜덤 값을 멘토 or 멘티 생성시 랜덤 값을 생성하여 저장 후 반환하는 방식으로 변경하였습니다.

## 작업 내용

- `/api/v1/temp-mentor`
- `/api/v1/temp-mentor/search/{userName}`
- `/api/v1/temp-mentor/{id}`
- `/api/v1/user/user-id`
- `/api/v1/board/{boardId}`
- `/api/v1/comment/{commentId}`

- 위 API 반환 값으로 `temporaryImgNumber` 필드를 추가하였습니다.

- `User` 엔티티를 생성할 때 해당 엔티티의 필드인 `temporaryImgNumber` 를 `0~6` 까지의 랜덤 값을 저장하여 멘토와 멘티 필드에 추가하였습니다.

## 추가 사항

`temporaryImgNumber` 값은 엔티티 생성 시에만 저장되기 때문에 기존 멘토, 멘티 엔티티의 필드 초기화가 필요합니다.
해당 DML 쿼리를 실행하여 `0~6`의 랜덤 값으로 대치하는 작업이 필요합니다.

```sql
UPDATE user
SET temporary_img_number = FLOOR(RAND() * 7);
```

```sql
UPDATE temp_mentor
SET temporary_img_number = FLOOR(RAND() * 7);
```