### PR TITLE
defaultImgNumber 초기값 설정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/domain/TempMentor.kt
@@ -39,5 +39,5 @@ class TempMentor(
     var deleted: Boolean = false,
 
     @Column(name = "default_img_number")
-    val defaultImgNumber: Int
+    val defaultImgNumber: Int = 0
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -37,8 +37,13 @@ class User(
     val profileUrl: String?,
 
     @Column(name = "default_img_number")
-    val defaultImgNumber: Int = generateRandomNumber()
+    var defaultImgNumber: Int = 0
 ) : BaseIdTimestampEntity() {
+
+    init {
+        defaultImgNumber = generateRandomNumber()
+    }
+
     companion object {
         private fun generateRandomNumber(): Int {
             return Random.nextInt(0, 5)


### PR DESCRIPTION
defaultImgNumber의 초기값을 설정하지 않아 원시타입인 Int 필드에 null 값이 들어가는 예외가 발생하였습니다.

- TempMentor의 defaultImgNumber필드의 초기값을 0으로 설정하였습니다
- User의 defaultImgNumber필드를 초기값을 0으로 설정하였고, 생성시점에 랜덤 값이 할당되도록 변경하였습니다.