### PR TITLE
게시글 cascade 설정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/domain/Comment.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/comment/domain/Comment.kt
@@ -21,7 +21,7 @@ class Comment(
     val parentComment: Comment?,
 
     // 해당 댓글의 대댓글 List
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "repliedComment")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "repliedComment", cascade = [CascadeType.ALL], orphanRemoval = true)
     val replyComment: MutableList<Comment> = ArrayList(),
 
     // 해당 댓글이 대댓글을 작성한 댓글

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -1,6 +1,7 @@
 package team.themoment.gsmNetworking.domain.user.domain
 
 import team.themoment.gsmNetworking.common.domain.BaseIdTimestampEntity
+import team.themoment.gsmNetworking.domain.board.domain.Board
 import team.themoment.gsmNetworking.domain.mentor.domain.Mentor
 import team.themoment.gsmNetworking.domain.user.converter.EncryptConverter
 import javax.persistence.*
@@ -37,7 +38,11 @@ class User(
     val profileUrl: String?,
 
     @Column(name = "default_img_number")
-    var defaultImgNumber: Int? = 0
+    var defaultImgNumber: Int? = 0,
+
+    @OneToMany(mappedBy = "author", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val boards: MutableList<Board> = ArrayList()
+
 ) : BaseIdTimestampEntity() {
 
     init {


### PR DESCRIPTION
## 개요
유저가 게시글을 작성한 상태에서 유저를 삭제할 때 연관관계 오류가 발생하는 현상을 해결하였습니다.

## 본문
- User - Board 간의 연관관계에서 CasCade ALL 설정
- Comment - replyComment 간의 연관관계에서 CasCade ALL 설정