### PR TITLE
프로필 사진 업로드 멘티 권한 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -107,14 +107,14 @@ class SecurityConfig(
                 Authority.USER.name,
                 Authority.TEMP_USER.name
             )
-            // /user
-            .mvcMatchers("/api/v1/user/**").hasAnyRole(
-                Authority.USER.name
-            )
             // /user/profile-url
             .mvcMatchers("/api/v1/user/profile-url").hasAnyRole(
                 Authority.USER.name,
                 Authority.TEMP_USER.name
+            )
+            // /user
+            .mvcMatchers("/api/v1/user/**").hasAnyRole(
+                Authority.USER.name
             )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -111,6 +111,11 @@ class SecurityConfig(
             .mvcMatchers("/api/v1/user/**").hasAnyRole(
                 Authority.USER.name
             )
+            // /user/profile-url
+            .mvcMatchers("/api/v1/user/profile-url").hasAnyRole(
+                Authority.USER.name,
+                Authority.TEMP_USER.name
+            )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(
                 Authority.USER.name,

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -113,7 +113,8 @@ class SecurityConfig(
             )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(
-                Authority.USER.name
+                Authority.USER.name,
+                Authority.TEMP_USER.name
             )
             // /gwangya
             .mvcMatchers(HttpMethod.GET, "/api/v1/gwangya/token").hasAnyRole(


### PR DESCRIPTION
## 개요

멘티도 프로필 사진 등록 API를 사용할 수 있게 권한을 확장하였습니다.

## 본문

- `/api/v1/file`, `/api/v1/user/profile-url` 해당 두 API에 대해 `TEMP_USER` 권한인 멘티도 요청을 보낼 수 있게 권한을 확장하였습니다.