### PR TITLE
선생님 권한인 사용자 인지 반환 API 권한 확장

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -111,6 +111,11 @@ class SecurityConfig(
             .mvcMatchers("/api/v1/user/**").hasAnyRole(
                 Authority.USER.name
             )
+            .mvcMatchers("/api/v1/user/is-teacher").hasAnyRole(
+                Authority.USER.name,
+                Authority.TEMP_USER.name,
+                Authority.TEACHER.name
+            )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(
                 Authority.USER.name

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -107,14 +107,15 @@ class SecurityConfig(
                 Authority.USER.name,
                 Authority.TEMP_USER.name
             )
+            // /user/is-teacher
+            .mvcMatchers("/api/v1/user/is-teacher").hasAnyRole(
+                Authority.TEMP_USER.name,
+                Authority.USER.name,
+                Authority.TEACHER.name
+            )
             // /user
             .mvcMatchers("/api/v1/user/**").hasAnyRole(
                 Authority.USER.name
-            )
-            .mvcMatchers("/api/v1/user/is-teacher").hasAnyRole(
-                Authority.USER.name,
-                Authority.TEMP_USER.name,
-                Authority.TEACHER.name
             )
             // /file
             .mvcMatchers("/api/v1/file").hasAnyRole(


### PR DESCRIPTION
선생님 권한인 사용자 인지 반환 API의 권한을 `USER`, `TEMP_USER`, `TEACHER` 권한으로 확장하였습니다.