### PR TITLE
나의 멘티 정보 반환 API 필드 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/dto/MenteeInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/dto/MenteeInfoDto.kt
@@ -11,5 +11,7 @@ data class MenteeInfoDto (
 
     val generation: Int,
 
-    val defaultImgNumber: Int
+    val defaultImgNumber: Int,
+
+    val profileUrl: String?
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/service/impl/MenteeService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentee/service/impl/MenteeService.kt
@@ -56,7 +56,8 @@ class MenteeService(
             email = userInfoDto.email,
             phoneNumber = userInfoDto.phoneNumber,
             generation = userInfoDto.generation,
-            defaultImgNumber = userInfoDto.defaultImgNumber
+            defaultImgNumber = userInfoDto.defaultImgNumber,
+            profileUrl = userInfoDto.profileUrl
         )
     }
 }


### PR DESCRIPTION
## 개요
나의 멘토 정보 반환 API에 프로필 사진 필드를 추가하였습니다.

## 본문
- 멘티도 프로필 이미지 등록이 가능해지면서 나의 멘티 정보 반환 API에 `profileUrl` 필드를 추가하였습니다.