### PR TITLE
HotFix 프로필 이미지 등록시 발생하는 이상현상

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/impl/UserService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/service/impl/UserService.kt
@@ -119,7 +119,11 @@ class UserService(
             email = user.email,
             phoneNumber = user.phoneNumber,
             snsUrl = user.snsUrl,
-            profileUrl = profileUrl
+            profileUrl = profileUrl,
+            defaultImgNumber = user.defaultImgNumber,
+            boards = user.boards,
+            comments = user.comments,
+            likes = user.likes
         )
 
         userRepository.save(userUpdatedProfileUrl)


### PR DESCRIPTION
프로필 이미지 등록시 해당 유저의 게시글이 삭제되는 현상이 발생하였습니다.

프로필 이미지 등록시 새로운 유저 객채를 생성하여 save하는데, boards, comments, likes, defaultImgNumber 컬럼이 누락되어 있어서 추가하였습니다.