### PR TITLE
프로필 이미지 등록 멘티 권한 확장

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -118,6 +118,7 @@ class SecurityConfig(
             )
             // /user/profile-url
             .mvcMatchers("/api/v1/user/profile-url").hasAnyRole(
+                Authority.UNAUTHENTICATED.name,
                 Authority.TEMP_USER.name,
                 Authority.USER.name,
                 Authority.TEACHER.name


### PR DESCRIPTION
## 개요
프로필 이미지 등록 API의 시큐리티 권한 매핑을 멘티 권한까지 확장하였습니다.