### PR TITLE
기본 이미지 변경 API 권한, 로직 설정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/user/domain/User.kt
@@ -37,7 +37,7 @@ class User(
     val snsUrl: String?,
 
     @Column(nullable = true)
-    val profileUrl: String?,
+    var profileUrl: String?,
 
     @Column(name = "default_img_number")
     var defaultImgNumber: Int = 0,
@@ -65,6 +65,10 @@ class User(
 
     fun updateProfileNumber(defaultImgNumber: Int) {
         this.defaultImgNumber = defaultImgNumber
+
+        if (this.profileUrl != null) {
+            this.profileUrl = null
+        }
     }
 
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -118,7 +118,12 @@ class SecurityConfig(
             )
             // /user/profile-url
             .mvcMatchers("/api/v1/user/profile-url").hasAnyRole(
-                Authority.UNAUTHENTICATED.name,
+                Authority.TEMP_USER.name,
+                Authority.USER.name,
+                Authority.TEACHER.name
+            )
+            // /user/profile-number
+            .mvcMatchers("/api/v1/user/profile-number").hasAnyRole(
                 Authority.TEMP_USER.name,
                 Authority.USER.name,
                 Authority.TEACHER.name

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -118,6 +118,7 @@ class SecurityConfig(
             )
             // /user/profile-url
             .mvcMatchers("/api/v1/user/profile-url").hasAnyRole(
+                Authority.UNAUTHENTICATED.name,
                 Authority.TEMP_USER.name,
                 Authority.USER.name,
                 Authority.TEACHER.name


### PR DESCRIPTION
## 개요

defualt 이미지 숫자 변경 API의 권한 설정과 로직을 수정하였습니다.

## 작업내용

- defualt 이미지 숫자 변경 API의 시큐리티 url 매핑 설정을 추가하였습니다.
- 변경시 프로필 url이 있다면 null로 변경하는 로직을 추가하였습니다.
   - 프로필 이미지가 등록되어 있는 상태에서 해당 API 호출시 default 이미지로 변경되기 위해 변경하였습니다.