### PR TITLE
이메일 엑추레이터 헬스체크 비활성화

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -115,6 +115,8 @@ management:
       enabled: false
     ping:
       enabled: false
+    mail:
+      enabled: false
   server:
     port: ${ACTUATOR_SERVER_PORT}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -111,6 +111,8 @@ management:
       enabled: false
     ping:
       enabled: false
+    mail:
+      enabled: false
   server:
     port: ${ACTUATOR_SERVER_PORT}
 


### PR DESCRIPTION
![image](https://github.com/themoment-team/GSM-Networking-server/assets/131235625/630ef1cc-b5fb-4481-819e-ba6addf65602)

서버버 로그에 지속적으로 `Too many login attempts, please try again later. For more information` 해당 오류 메시지가 지속적으로 발생하였습니다.

스프링 엑추레이터가 헬스체크를 진행 시 `MailHealthIndicator` 에서 메일 서버 테스트 커넥트를 진행하는 것을 확인하였습니다.
해당 작업을 주기적으로 실행하는것은 어플리케이션에 영향을 줄 수 있다고 생각하여 mail에 관련된 헬스체크를 진행하지 않도록 설정을 추가하였습니다.

### 추가사항

해당 작업 이후 주기적을 발생하는 헬스체크에서 메일관련 헬스체크를 disabled하여 어플리케이션의 다른 로직들까지 영향을 주는것을 막은 작업입니다.
추가로 메일을 전송하는 로직을 동작시 위의 오류가 발생하는 것을 확인하였습니다. 해당 부분에 대해 추후에 원인을 파악하여 고쳐보도록 하겠습니다.