### PR TITLE
누락된 게시글 관련 시큐리티 권한 매핑 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -139,6 +139,13 @@ class SecurityConfig(
                 Authority.TEMP_USER.name,
                 Authority.TEACHER.name
             )
+            // board
+            .mvcMatchers("/api/v1/board/*").hasAnyRole(
+                Authority.TEMP_USER.name,
+                Authority.USER.name,
+                Authority.ADMIN.name,
+                Authority.TEACHER.name
+            )
             // /gwangya
             .mvcMatchers(HttpMethod.GET, "/api/v1/gwangya/token").hasAnyRole(
                 Authority.UNAUTHENTICATED.name,

--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -146,6 +146,10 @@ class SecurityConfig(
                 Authority.ADMIN.name,
                 Authority.TEACHER.name
             )
+            // pin
+            .mvcMatchers(HttpMethod.PATCH, "/api/v1/board/pin/*").hasAnyRole(
+                Authority.TEACHER.name
+            )
             // /gwangya
             .mvcMatchers(HttpMethod.GET, "/api/v1/gwangya/token").hasAnyRole(
                 Authority.UNAUTHENTICATED.name,


### PR DESCRIPTION
## 개요
누락된 게시글 관련 권한 매핑을 추가하였습니다.

## 작업내용
- 게시글 관련 API 권한 매핑 추가 (TEMP_USER, USER, TEACH, ADMIN)
- 게시글 고정 API 권한 매핑 추가 (TEACHER)