### PR TITLE
멘토 관련 API 권한 매핑 수정

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/global/security/SecurityConfig.kt
@@ -61,10 +61,6 @@ class SecurityConfig(
     private fun authorizeHttpRequests(http: HttpSecurity) {
         http.authorizeHttpRequests()
             // /mentor
-            .mvcMatchers("/api/v1/mentor/**").hasAnyRole(
-                Authority.USER.name,
-                Authority.TEACHER.name
-            )
             .mvcMatchers(HttpMethod.GET, "/api/v1/mentor").hasAnyRole(
                 Authority.TEMP_USER.name,
                 Authority.USER.name,
@@ -76,6 +72,10 @@ class SecurityConfig(
                 Authority.TEMP_USER.name
             )
             .mvcMatchers("/api/v1/mentor/my").hasAnyRole(
+                Authority.USER.name,
+                Authority.TEACHER.name
+            )
+            .mvcMatchers("/api/v1/mentor/**").hasAnyRole(
                 Authority.USER.name,
                 Authority.TEACHER.name
             )


### PR DESCRIPTION
멘티가 멘토 리스트 API에 대해 403 에러가 발생하여 멘토 관련 권한 매핑의 레벨을 수정하였습니다.

- `/api/v1/mentor/**` (멘토, 선생님)
- `/api/v1/mentor` GET (멘티, 멘토, 선생님 ...)
- `/api/v1/mentor` POST (멘티, 인증 안된 유저)

위와 같은 구조를 아래와 같이 변경하였습니다.

- `/api/v1/mentor` GET (멘티, 멘토, 선생님 ...)
- `/api/v1/mentor` POST (멘티, 인증 안된 유저)
- `/api/v1/mentor/**` (멘토, 선생님)