### PR TITLE
게시글 작성자, 멘토 리스트 dto phoneNumber 필드 추가

### DIFF
--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/dto/BoardAuthorDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/dto/BoardAuthorDto.kt
@@ -1,0 +1,10 @@
+package team.themoment.gsmNetworking.domain.board.dto
+
+data class BoardAuthorDto (
+    val id: Long,
+    val name: String,
+    val generation: Int,
+    val profileUrl: String?,
+    val defaultImgNumber: Int,
+    val phoneNumber: String
+)

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/dto/BoardInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/dto/BoardInfoDto.kt
@@ -11,7 +11,7 @@ data class BoardInfoDto (
     val title: String,
     val content: String,
     val boardCategory: BoardCategory,
-    val author: AuthorDto,
+    val author: BoardAuthorDto,
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val createdAt: LocalDateTime,
     val comments: List<CommentListDto>,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/board/service/impl/BoardService.kt
@@ -93,12 +93,13 @@ class BoardService(
             title = savedBoard.title,
             content = savedBoard.content,
             boardCategory = savedBoard.boardCategory,
-            author = AuthorDto(
+            author = BoardAuthorDto(
                 id = savedBoard.author.id,
                 name = savedBoard.author.name,
                 generation = savedBoard.author.generation,
                 profileUrl = savedBoard.author.profileUrl,
-                defaultImgNumber = savedBoard.author.defaultImgNumber
+                defaultImgNumber = savedBoard.author.defaultImgNumber,
+                phoneNumber = savedBoard.author.phoneNumber
             ),
             createdAt = savedBoard.createdAt,
             comments = listOf(),
@@ -145,12 +146,13 @@ class BoardService(
             title = currentBoard.title,
             content = currentBoard.content,
             boardCategory = currentBoard.boardCategory,
-            author = AuthorDto(
+            author = BoardAuthorDto(
                 id = currentBoard.author.id,
                 name = currentBoard.author.name,
                 generation = currentBoard.author.generation,
                 profileUrl = currentBoard.author.profileUrl,
-                defaultImgNumber = currentBoard.author.defaultImgNumber
+                defaultImgNumber = currentBoard.author.defaultImgNumber,
+                phoneNumber = currentBoard.author.phoneNumber
             ),
             createdAt = currentBoard.createdAt,
             comments = getFindComments(findComments),
@@ -296,12 +298,13 @@ class BoardService(
             title = saveBoard.title,
             content = saveBoard.content,
             boardCategory = saveBoard.boardCategory,
-            author = AuthorDto(
+            author = BoardAuthorDto(
                 id = saveBoard.author.id,
                 name = saveBoard.author.name,
                 generation = saveBoard.author.generation,
                 profileUrl = saveBoard.author.profileUrl,
-                defaultImgNumber = saveBoard.author.defaultImgNumber
+                defaultImgNumber = saveBoard.author.defaultImgNumber,
+                phoneNumber = saveBoard.author.phoneNumber
             ),
             comments = getFindComments(saveBoard.comments),
             likeCount = saveBoard.likes.size,

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/MentorInfoDto.kt
@@ -13,5 +13,6 @@ data class MentorInfoDto(
     val sns: String?,
     val profileUrl: String?,
     val registered: Boolean,
-    val defaultImgNumber: Int
+    val defaultImgNumber: Int,
+    val phoneNumber: String?
 )

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/dto/TempMentorInfoDto.kt
@@ -23,6 +23,7 @@ data class TempMentorInfoDto(
         sns = snsUrl,
         profileUrl = null,
         registered = false,
-        defaultImgNumber = defaultImgNumber
+        defaultImgNumber = defaultImgNumber,
+        phoneNumber = null,
     )
 }

--- a/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
+++ b/src/main/kotlin/team/themoment/gsmNetworking/domain/mentor/repository/MentorCustomRepositoryImpl.kt
@@ -41,7 +41,8 @@ class MentorCustomRepositoryImpl(
                 mentor.user.snsUrl,
                 mentor.user.profileUrl,
                 mentor.registered,
-                mentor.user.defaultImgNumber
+                mentor.user.defaultImgNumber,
+                mentor.user.phoneNumber
             )
         )
             .from(mentor, career)

--- a/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
+++ b/src/test/kotlin/team/themoment/gsmNetworking/domain/mentor/service/QueryAllMentorsUseCaseTest.kt
@@ -61,7 +61,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/a",
             profileUrl = "https://www.instagram.com/img/a",
             registered = true,
-            defaultImgNumber = 0
+            defaultImgNumber = 0,
+            phoneNumber = "01000000000"
         ),
         MentorInfoDto(
             id = 2L,
@@ -78,7 +79,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/b",
             profileUrl = "https://www.instagram.com/img/b",
             registered = true,
-            defaultImgNumber = 1
+            defaultImgNumber = 1,
+            phoneNumber = "01000000000"
         ),
         MentorInfoDto(
             id = 3L,
@@ -95,7 +97,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/c",
             profileUrl = "https://www.instagram.com/img/c",
             registered = true,
-            defaultImgNumber = 2
+            defaultImgNumber = 2,
+            phoneNumber = "01000000000"
         ),
         MentorInfoDto(
             id = 4L,
@@ -112,7 +115,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
             sns = "https://www.instagram.com/d",
             profileUrl = "https://www.instagram.com/img/d",
             registered = true,
-            defaultImgNumber = 3
+            defaultImgNumber = 3,
+            phoneNumber = "01000000000"
         )
     )
 
@@ -194,7 +198,8 @@ class QueryAllMentorsUseCaseTest : BehaviorSpec({
         sns = "https://www.instagram.com/a",
         profileUrl = "https://www.instagram.com/img/a",
         registered = true,
-        defaultImgNumber = 3
+        defaultImgNumber = 3,
+        phoneNumber = "01000000000"
     )
 
     val sameUserTempMentor = TempMentorInfoDto(


### PR DESCRIPTION
## 개요

OS 내장 메신저를 사용하는 기능 적용을 위해 게시글 상세조회 작성자와 멘토 리스트 API response에 phoneNumber 필드를 추가하였습니다.